### PR TITLE
Benchmarks: Add Feature - Add interface to get all predefine parameters of all benchmarks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SuperBenchmark
 
-[![Build Status](https://dev.azure.com/msrasrg/SuperBenchmark/_apis/build/status/microsoft.superbenchmark?branchName=dev)](https://dev.azure.com/msrasrg/SuperBenchmark/_build?definitionId=77)
+[![Build Status](https://dev.azure.com/msrasrg/SuperBenchmark/_apis/build/status/cuda-unit-test?branchName=dev)](https://dev.azure.com/msrasrg/SuperBenchmark/_build/latest?definitionId=80&branchName=dev)
 [![Lint](https://github.com/microsoft/superbenchmark/workflows/Lint/badge.svg)](https://github.com/microsoft/superbenchmark/actions?query=workflow%3ALint)
 [![Codecov](https://codecov.io/gh/microsoft/superbenchmark/branch/dev/graph/badge.svg?token=DDiDLW7pSd)](https://codecov.io/gh/microsoft/superbenchmark/branch/dev)
 
@@ -21,46 +21,77 @@ which supports:
 It includes micro-benchmark for primitive computation and communication benchmarking,
 and model-benchmark to measure domain-aware end-to-end deep learning workloads.
 
+> 🔴 __Note__:
+SuperBench is in the early pre-alpha stage for open source, and not ready for general public yet.
+If you want to jump in early, you can try building [`dev` branch](https://github.com/microsoft/superbenchmark/tree/dev) yourself.
+
 
 ## Installation
 
+### Using Docker (_Preferred_)
+
+__System Requirements__
+
+* Platform: Ubuntu 18.04 or later (64-bit)
+* Docker: Docker CE 19.03 or later
+
+__Install SuperBench__
+
+* Using Pre-Build Images
+
+    ```sh
+    docker pull superbench/superbench:dev-cuda11.1.1
+    docker run -it --rm \
+        --privileged --net=host --ipc=host --gpus=all \
+        superbench/superbench:dev-cuda11.1.1 bash
+    ```
+
+* Building the Image
+
+    ```sh
+    docker build -f dockerfile/cuda11.1.1.dockerfile -t superbench/superbench:dev .
+    ```
+
 ### Using Python
 
-System requirements:
+__System Requirements__
+
+* Platform: Ubuntu 18.04 or later (64-bit); Windows 10 (64-bit) with WSL2
 * Python: Python 3.6 or later, pip 18.0 or later
-* Platform: Ubuntu 16.04 or later (64-bit), Windows 10 (64-bit) with WSL2
 
-Check whether Python environment is already configured:
-```sh
-# check Python version
-python3 --version
-# check pip version
-python3 -m pip --version
-```
-If not, install the followings:
-* [Python](https://www.python.org/)
-* [pip](https://pip.pypa.io/en/stable/installing/)
-* [venv](https://docs.python.org/3/library/venv.html)
+    Check whether Python environment is already configured:
+    ```sh
+    # check Python version
+    python3 --version
+    # check pip version
+    python3 -m pip --version
+    ```
+    If not, install the followings:
+    * [Python](https://www.python.org/)
+    * [pip](https://pip.pypa.io/en/stable/installing/)
+    * [venv](https://docs.python.org/3/library/venv.html)
 
-It's recommended to use a virtual environment (optional):
-```sh
-# create a new virtual environment
-python3 -m venv --system-site-packages ./venv
-# activate the virtual environment
-source ./venv/bin/activate
+    It's recommended to use a virtual environment (optional):
+    ```sh
+    # create a new virtual environment
+    python3 -m venv --system-site-packages ./venv
+    # activate the virtual environment
+    source ./venv/bin/activate
 
-# exit the virtual environment later
-# after you finish running superbench
-deactivate
-```
+    # exit the virtual environment later
+    # after you finish running superbench
+    deactivate
+    ```
 
-Then install superbench through either PyPI binary or from source:
+__Install SuperBench__
 
-1. PyPI Binary
+* PyPI Binary
 
-    TODO
+    ```sh
+    # not available yet
+    ```
 
-2. From Source
+* From Source
 
     ```sh
     # get source code
@@ -71,14 +102,22 @@ Then install superbench through either PyPI binary or from source:
     python3 -m pip install .
     ```
 
-### Using Docker
-
-TODO
-
 
 ## Usage
 
-TODO
+### Run SuperBench
+
+```sh
+# run benchmarks in default settings
+sb exec
+
+# use a custom config
+sb exec --config-file ./superbench/config/default.yaml
+```
+
+### Benchmark Gallary
+
+Please find more benchmark examples [here](examples/benchmarks/).
 
 
 ## Developer Guide
@@ -146,16 +185,16 @@ SuperBenchmark is an open-source project. Your participation and contribution ar
 1. Bug fixes for existing features.
 2. New features for benchmark module (micro-benchmark, model-benchmark, etc.)
 
-   If you would like to contribute a new feature on SuperBenchmark, please submit your proposal first. In [GitHub Issues](https://github.com/microsoft/superbenchmark/issues) module, choose `Enhancement Request` to finish the submission. If the proposal is accepted, you can submit pull request to origin dev branch.
+   If you would like to contribute a new feature on SuperBenchmark, please submit your proposal first. In [GitHub Issues](https://github.com/microsoft/superbenchmark/issues) module, choose `Enhancement Request` to finish the submission. If the proposal is accepted, you can submit pull request to origin [`dev` branch](https://github.com/microsoft/superbenchmark/tree/dev).
 
 #### Contribution steps
 
 If you would like to contribute to the project, please follow below steps of joint development on GitHub.
 
 1. `Fork` the repo first to your personal GitHub account.
-2. Check out from `dev` branch for feature development.
+2. Check out from [`dev` branch](https://github.com/microsoft/superbenchmark/tree/dev) for feature development.
 3. When you finish the feature, please fetch the latest code from origin repo, merge to your branch and resolve conflict.
-4. Submit pull request to origin `dev` branch.
+4. Submit pull request to origin [`dev` branch](https://github.com/microsoft/superbenchmark/tree/dev).
 5. Please note that there might be comments or questions from reviewers. It will need your help to update the pull request.
 
 ## Trademarks

--- a/superbench/benchmarks/base.py
+++ b/superbench/benchmarks/base.py
@@ -23,7 +23,7 @@ class Benchmark(ABC):
             parameters (str): benchmark parameters.
         """
         self._name = name
-        self._argv = list(filter(None, parameters.split(' ')))
+        self._argv = list(filter(None, parameters.split(' '))) if parameters is not None else list()
         self._benchmark_type = None
         self._parser = argparse.ArgumentParser(
             add_help=False,

--- a/superbench/benchmarks/registry.py
+++ b/superbench/benchmarks/registry.py
@@ -157,7 +157,7 @@ class BenchmarkRegistry:
 
     @classmethod
     def get_all_benchmark_predefine_settings(cls):
-        """Get all registerred benchmarks' predefine settings.
+        """Get all registered benchmarks' predefine settings.
 
         Return:
             benchmark_params (dict[str, dict]): key is benchmark name,

--- a/superbench/benchmarks/registry.py
+++ b/superbench/benchmarks/registry.py
@@ -23,7 +23,7 @@ class BenchmarkRegistry:
     benchmarks: Dict[str, dict] = dict()
 
     @classmethod
-    def register_benchmark(cls, name, class_def, parameters=None, platform=None):
+    def register_benchmark(cls, name, class_def, parameters='', platform=None):
         """Register new benchmark, key is the benchmark name.
 
         Args:

--- a/superbench/benchmarks/registry.py
+++ b/superbench/benchmarks/registry.py
@@ -67,6 +67,18 @@ class BenchmarkRegistry:
 
                 cls.benchmarks[name][p] = (class_def, parameters)
 
+        benchmark = class_def(name, parameters)
+        benchmark.add_parser_arguments()
+        ret, args, unknown = benchmark.parse_args()
+        if not ret or len(unknown) >= 1:
+            logger.log_and_raise(
+                TypeError,
+                'Registered benchmark has invalid arguments - benchmark: {}, parameters: {}'.format(name, parameters)
+            )
+        else:
+            cls.benchmarks[name]['predefine_param'] = vars(args)
+            logger.info('Benchmark registration - benchmark: {}, predefine_parameters: {}'.format(name, vars(args)))
+
     @classmethod
     def is_benchmark_context_valid(cls, benchmark_context):
         """Check wether the benchmark context is valid or not.
@@ -142,6 +154,19 @@ class BenchmarkRegistry:
             return benchmark.get_configurable_settings()
         else:
             return None
+
+    @classmethod
+    def get_all_benchmark_predefine_settings(cls):
+        """Get all registerred benchmarks' predefine settings.
+
+        Return:
+            benchmark_params (dict[str, dict]): key is benchmark name,
+              value is the dict with structure: {'parameter': default_value}.
+        """
+        benchmark_params = dict()
+        for name in cls.benchmarks:
+            benchmark_params[name] = cls.benchmarks[name]['predefine_param']
+        return benchmark_params
 
     @classmethod
     def launch_benchmark(cls, benchmark_context):

--- a/tests/benchmarks/test_registry.py
+++ b/tests/benchmarks/test_registry.py
@@ -202,7 +202,6 @@ def test_launch_benchmark():
 def test_get_all_benchmark_predefine_settings():
     """Test interface BenchmarkRegistry.get_all_benchmark_predefine_settings()."""
     benchmark_params = BenchmarkRegistry.get_all_benchmark_predefine_settings()
-    print(benchmark_params)
 
     # Choose benchmark 'pytorch-sharding-matmul' for testing.
     benchmark_name = 'pytorch-sharding-matmul'

--- a/tests/benchmarks/test_registry.py
+++ b/tests/benchmarks/test_registry.py
@@ -7,6 +7,7 @@ import re
 
 from superbench.benchmarks import Platform, Framework, BenchmarkType, BenchmarkRegistry, ReturnCode
 from superbench.benchmarks.micro_benchmarks import MicroBenchmark
+from superbench.benchmarks.micro_benchmarks.sharding_matmul import ShardingMode
 
 
 class AccumulationBenchmark(MicroBenchmark):
@@ -196,3 +197,21 @@ def test_launch_benchmark():
     benchmark = BenchmarkRegistry.launch_benchmark(context)
     assert (benchmark)
     assert (benchmark.return_code == ReturnCode.INVALID_ARGUMENT)
+
+
+def test_get_all_benchmark_predefine_settings():
+    """Test interface BenchmarkRegistry.get_all_benchmark_predefine_settings()."""
+    benchmark_params = BenchmarkRegistry.get_all_benchmark_predefine_settings()
+    print(benchmark_params)
+
+    # Choose benchmark 'pytorch-sharding-matmul' for testing.
+    benchmark_name = 'pytorch-sharding-matmul'
+    assert (benchmark_name in benchmark_params)
+    assert (benchmark_params[benchmark_name]['run_count'] == 1)
+    assert (benchmark_params[benchmark_name]['duration'] == 0)
+    assert (benchmark_params[benchmark_name]['n'] == 4096)
+    assert (benchmark_params[benchmark_name]['k'] == 4096)
+    assert (benchmark_params[benchmark_name]['m'] == 4096)
+    assert (benchmark_params[benchmark_name]['mode'] == [ShardingMode.ALLREDUCE, ShardingMode.ALLGATHER])
+    assert (benchmark_params[benchmark_name]['num_warmup'] == 10)
+    assert (benchmark_params[benchmark_name]['num_steps'] == 500)


### PR DESCRIPTION
**Description**
Add BenchmarkRegistry.get_all_benchmark_predefine_settings() interface to get all predefine parameters of all benchmarks. The result type is dict[str, dict] , key is benchmark name, value is the dict with structure: {'parameter': default_value}. Currently the result looks like:

> {'pytorch-bert-large': {'run_count': 1, 'duration': 0, 'num_warmup': 64, 'num_steps': 2048, 'sample_count': 128, 'batch_size': 32, 'precision': [<Precision.FLOAT32: 'float32'>, <Precision.FLOAT16: 'float16'>], 'model_action': [<ModelAction.TRAIN: 'train'>], 'distributed_impl': None, 'distributed_backend': None, 'no_gpu': False, 'num_classes': 100, 'hidden_size': 1024, 'num_hidden_layers': 24, 'num_attention_heads': 16, 'intermediate_size': 4096, 'seq_len': 512}, 'pytorch-bert-base': {'run_count': 1, 'duration': 0, 'num_warmup': 64, 'num_steps': 2048, 'sample_count': 128, 'batch_size': 32, 'precision': [<Precision.FLOAT32: 'float32'>, <Precision.FLOAT16: 'float16'>], 'model_action': [<ModelAction.TRAIN: 'train'>], 'distributed_impl': None, 'distributed_backend': None, 'no_gpu': False, 'num_classes': 100, 'hidden_size': 768, 'num_hidden_layers': 12, 'num_attention_heads': 12, 'intermediate_size': 3072, 'seq_len': 512}, 'pytorch-sharding-matmul': {'run_count': 1, 'duration': 0, 'n': 4096, 'k': 4096, 'm': 4096, 'mode': [<ShardingMode.ALLREDUCE: 'allreduce'>, <ShardingMode.ALLGATHER: 'allgather'>], 'num_warmup': 10, 'num_steps': 500}, 'pytorch-matmul': {'run_count': 1, 'duration': 0, 'n': 4096, 'k': 4096, 'm': 4096, 'mode': [<ShardingMode.NOSHARDING: 'nosharding'>], 'num_warmup': 10, 'num_steps': 500}}

