### PR TITLE
Benchmarks: Fix Bug - Increase default sample count for benchmarking.

### DIFF
--- a/superbench/benchmarks/model_benchmarks/model_base.py
+++ b/superbench/benchmarks/model_benchmarks/model_base.py
@@ -81,7 +81,7 @@ class ModelBenchmark(Benchmark):
         self._parser.add_argument(
             '--sample_count',
             type=int,
-            default=128,
+            default=1024,
             required=False,
             help='The number of data samples in dataset.',
         )


### PR DESCRIPTION
**Description**
Increase the default sample count to make sure it is sufficient for distribution with all workers.
If batch_size = 32, then 1024 is enough for 32 workers to run one step.

