### PR TITLE
Utils - Support lazy import

### DIFF
--- a/superbench/benchmarks/__init__.py
+++ b/superbench/benchmarks/__init__.py
@@ -3,10 +3,22 @@
 
 """Exposes interfaces of benchmarks used by SuperBench executor."""
 
+import importlib
+
 from superbench.benchmarks.return_code import ReturnCode
 from superbench.benchmarks.context import Platform, Framework, Precision, ModelAction, BenchmarkType, BenchmarkContext
-from superbench.benchmarks.registry import BenchmarkRegistry
-from superbench.benchmarks import model_benchmarks, micro_benchmarks, docker_benchmarks    # noqa pylint: disable=unused-import
+from superbench.common.utils import LazyImport
+
+BenchmarkRegistry = LazyImport(
+    'superbench.benchmarks.registry', 'BenchmarkRegistry', lambda: list(
+        map(
+            importlib.import_module, [
+                'superbench.benchmarks.{}'.format(module)
+                for module in ['model_benchmarks', 'micro_benchmarks', 'docker_benchmarks']
+            ]
+        )
+    )
+)
 
 __all__ = [
     'ReturnCode', 'Platform', 'Framework', 'BenchmarkType', 'Precision', 'ModelAction', 'BenchmarkContext',

--- a/superbench/common/utils/__init__.py
+++ b/superbench/common/utils/__init__.py
@@ -5,5 +5,6 @@
 
 from superbench.common.utils.logging import SuperBenchLogger, logger
 from superbench.common.utils.file_handler import create_output_dir, get_sb_config
+from superbench.common.utils.lazy_import import LazyImport
 
-__all__ = ['SuperBenchLogger', 'logger', 'create_output_dir', 'get_sb_config']
+__all__ = ['SuperBenchLogger', 'logger', 'create_output_dir', 'get_sb_config', 'LazyImport']

--- a/superbench/common/utils/lazy_import.py
+++ b/superbench/common/utils/lazy_import.py
@@ -1,0 +1,52 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Lazy import utility."""
+
+import importlib
+
+
+class LazyImport:
+    """Lazy import Python moduels, only import when modules are used."""
+    def __init__(self, name, attr=None, callback=None):
+        """Init lazy import class.
+
+        Args:
+            name (str): Python module name.
+            attr (str, optional): Function or class name in the module. Defaults to None.
+            callback (callable, optional): Callback function. Defaults to None.
+        """
+        self._module = None
+        self._name = name
+        self._attr = attr
+        self._callback = callback
+
+    def _import(self):
+        """Import the needed module when it is used."""
+        if self._module is None:
+            self._module = importlib.import_module(self._name)
+            if self._attr is not None:
+                self._module = getattr(self._module, self._attr)
+            if self._callback is not None:
+                self._callback()
+
+    def __getattr__(self, item):
+        """Override __getattr__.
+
+        Args:
+            item (str): Attribute name.
+
+        Returns:
+            Any: Attribute value.
+        """
+        self._import()
+        return getattr(self._module, item)
+
+    def __dir__(self):
+        """Override __dir__.
+
+        Returns:
+            List[str]: The list of attributes.
+        """
+        self._import()
+        return dir(self._module)


### PR DESCRIPTION
__Major Revision__

* Support lazy import.
* Not importing benchmarks when running `help`, `version`, `deploy` commands, etc.
