### PR TITLE
Benchmarks: Build Pipeline - Call build script when setup environment.

### DIFF
--- a/.azure-pipelines/cuda-unit-test.yml
+++ b/.azure-pipelines/cuda-unit-test.yml
@@ -16,6 +16,9 @@ steps:
       python3 -m pip install .[test,torch]
     displayName: Install dependencies
   - script: |
+      make cppbuild
+    displayName: Build benchmarks
+  - script: |
       python3 setup.py lint
     displayName: Run code lint
   - script: |

--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,4 @@ cppformat:
 	clang-format --verbose -i $(CPPSOURCES)
 
 cppbuild:
-	cd ./superbench/benchmarks/; bash build.sh
+	cd ./superbench/benchmarks/ &&  bash build.sh

--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,4 @@ cppformat:
 	clang-format --verbose -i $(CPPSOURCES)
 
 cppbuild:
-	cd ./superbench/benchmarks/ &&  bash build.sh
+	cd ./superbench/benchmarks/ && bash build.sh

--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,6 @@ cpplint:
 
 cppformat:
 	clang-format --verbose -i $(CPPSOURCES)
+
+cppbuild:
+	cd ./superbench/benchmarks/; bash build.sh

--- a/dockerfile/cuda11.1.1.dockerfile
+++ b/dockerfile/cuda11.1.1.dockerfile
@@ -86,6 +86,7 @@ ENV PATH="${PATH}:/usr/local/cmake/bin:/usr/local/nccl-tests/build" \
 ARG SB_VERSION="main"
 RUN git clone -b ${SB_VERSION} https://github.com/microsoft/superbenchmark ${SB_HOME} && \
     cd ${SB_HOME} && \
-    python3 -m pip install .[torch]
+    python3 -m pip install .[torch] && \
+    make cppbuild
 
 WORKDIR ${SB_HOME}


### PR DESCRIPTION
**Description**
Call build script when setup environment.

**Major Revision**
- Call build script of benchmarks in Makefile, the command is `make cppbuild`
- Add cppbuild command for testing env.
- Add cppbuild command for docker image.