### PR TITLE
Benchmarks: Build Pipeline - Revise path of installing cmake projects

### DIFF
--- a/.azure-pipelines/cuda-unit-test.yml
+++ b/.azure-pipelines/cuda-unit-test.yml
@@ -20,13 +20,13 @@ steps:
       make postinstall
     displayName: Install dependencies
   - script: |
-      SB_MICRO_PATH=$PWD/bin make cppbuild
+      SB_MICRO_PATH=$PWD make cppbuild
     displayName: Build benchmarks
   - script: |
       python3 setup.py lint
     displayName: Run code lint
   - script: |
-      SB_MICRO_PATH=$PWD/bin python3 setup.py test
+      SB_MICRO_PATH=$PWD python3 setup.py test
     displayName: Run unit tests
     timeoutInMinutes: 10
   - script: |

--- a/superbench/benchmarks/build.sh
+++ b/superbench/benchmarks/build.sh
@@ -4,8 +4,7 @@
 # Licensed under the MIT License
 
 
-SB_MICRO_PATH="${SB_MICRO_PATH:-/usr/local/bin}"
-SB_MICRO_LIB="${SB_MICRO_LIB:-/usr/local/lib}"
+SB_MICRO_PATH="${SB_MICRO_PATH:-/usr/local}"
 
 for dir in micro_benchmarks/*/ ; do
     if [ -f $dir/CMakeLists.txt ]; then

--- a/superbench/benchmarks/micro_benchmarks/kernel_launch_overhead/CMakeLists.txt
+++ b/superbench/benchmarks/micro_benchmarks/kernel_launch_overhead/CMakeLists.txt
@@ -8,4 +8,4 @@ include(../cuda_common.cmake)
 
 add_executable(kernel_launch_overhead cuda_kernel_launch.cu)
 set_property(TARGET kernel_launch_overhead PROPERTY CUDA_ARCHITECTURES ${NVCC_ARCHS_SUPPORTED})
-install (TARGETS kernel_launch_overhead RUNTIME DESTINATION .)
+install(TARGETS kernel_launch_overhead RUNTIME DESTINATION bin)

--- a/superbench/benchmarks/micro_benchmarks/micro_base.py
+++ b/superbench/benchmarks/micro_benchmarks/micro_base.py
@@ -147,7 +147,8 @@ class MicroBenchmarkWithInvoke(MicroBenchmark):
         # Set the environment path.
         if os.getenv('SB_MICRO_PATH'):
             os.environ['PATH'] = os.path.join(os.getenv('SB_MICRO_PATH'), 'bin') + os.pathsep + os.getenv('PATH', '')
-            os.environ['PATH'] = os.path.join(os.getenv('SB_MICRO_PATH'), 'lib') + os.pathsep + os.getenv('PATH', '')
+            os.environ['LD_LIBRARY_PATH'] = os.path.join(os.getenv('SB_MICRO_PATH'),
+                                                         'lib') + os.pathsep + os.getenv('LD_LIBRARY_PATH', '')
 
         if not self._set_binary_path():
             return False

--- a/superbench/benchmarks/micro_benchmarks/micro_base.py
+++ b/superbench/benchmarks/micro_benchmarks/micro_base.py
@@ -145,8 +145,9 @@ class MicroBenchmarkWithInvoke(MicroBenchmark):
             return False
 
         # Set the environment path.
-        if 'SB_MICRO_PATH' in os.environ:
-            os.environ['PATH'] = os.getenv('SB_MICRO_PATH', '') + os.pathsep + os.getenv('PATH', '')
+        if os.getenv('SB_MICRO_PATH'):
+            os.environ['PATH'] = os.path.join(os.getenv('SB_MICRO_PATH'), 'bin') + os.pathsep + os.getenv('PATH', '')
+            os.environ['PATH'] = os.path.join(os.getenv('SB_MICRO_PATH'), 'lib') + os.pathsep + os.getenv('PATH', '')
 
         if not self._set_binary_path():
             return False


### PR DESCRIPTION
**Description**
Revise path of installing cmake projects

**Major Revision**
- unify SB_MICRO_PATH  to one base path, bin will be installed in SB_MICRO_PATH/bin , library will be installed in SB_MICRO_PATH/lib

