### PR TITLE
Bug bash - Rename bin name and metric name of cublas and cudnn microbenchmark

### DIFF
--- a/superbench/benchmarks/micro_benchmarks/cublas_function.py
+++ b/superbench/benchmarks/micro_benchmarks/cublas_function.py
@@ -181,7 +181,7 @@ class CublasBenchmark(MicroBenchmarkWithInvoke):
             }
         ]
 
-        self._bin_name = 'CublasBenchmark'
+        self._bin_name = 'cublas_benchmark'
 
     def add_parser_arguments(self):
         """Add the specified arguments."""
@@ -276,7 +276,16 @@ class CublasBenchmark(MicroBenchmarkWithInvoke):
             raw_data = []
             for line in lines:
                 if '[function config]' in line:
-                    metric = line[line.index('[function config]: ') + len('[function config]: '):]
+                    metric = ''
+                    metric_json_str = line[line.index('[function config]: ') +
+                                           len('[function config]: '):].replace(' ', '').replace(':', '_')[1:-1]
+                    metric_list = metric_json_str.split(',')
+                    print(metric_list)
+                    for key in metric_list:
+                        if 'name' in key:
+                            metric = key + metric
+                        else:
+                            metric = metric + '_' + key
                 if '[raw_data]' in line:
                     raw_data = line[line.index('[raw_data]: ') + len('[raw_data]: '):]
                     raw_data = raw_data.split(',')

--- a/superbench/benchmarks/micro_benchmarks/cublas_function.py
+++ b/superbench/benchmarks/micro_benchmarks/cublas_function.py
@@ -280,7 +280,6 @@ class CublasBenchmark(MicroBenchmarkWithInvoke):
                     metric_json_str = line[line.index('[function config]: ') +
                                            len('[function config]: '):].replace(' ', '').replace(':', '_')[1:-1]
                     metric_list = metric_json_str.split(',')
-                    print(metric_list)
                     for key in metric_list:
                         if 'name' in key:
                             metric = key + metric

--- a/superbench/benchmarks/micro_benchmarks/cublas_function/CMakeLists.txt
+++ b/superbench/benchmarks/micro_benchmarks/cublas_function/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 cmake_minimum_required(VERSION 3.18)
-project(CublasBenchmark LANGUAGES CUDA CXX)
+project(cublas_benchmark LANGUAGES CUDA CXX)
 
 include(../cuda_common.cmake)
 
@@ -25,7 +25,7 @@ if(NOT json_POPULATED)
   add_subdirectory(${json_SOURCE_DIR} ${json_BINARY_DIR} EXCLUDE_FROM_ALL)
 endif()
 
-add_executable(CublasBenchmark cublas_test.cpp)   
-target_link_libraries(CublasBenchmark ${TARGET_NAME} nlohmann_json::nlohmann_json CUDA::cudart CUDA::cublas) 
+add_executable(cublas_benchmark cublas_test.cpp)   
+target_link_libraries(cublas_benchmark ${TARGET_NAME} nlohmann_json::nlohmann_json CUDA::cudart CUDA::cublas) 
 
-install(TARGETS CublasBenchmark ${TARGET_NAME} RUNTIME DESTINATION bin LIBRARY DESTINATION lib)
+install(TARGETS cublas_benchmark ${TARGET_NAME} RUNTIME DESTINATION bin LIBRARY DESTINATION lib)

--- a/superbench/benchmarks/micro_benchmarks/cudnn_function.py
+++ b/superbench/benchmarks/micro_benchmarks/cudnn_function.py
@@ -414,7 +414,6 @@ class CudnnBenchmark(MicroBenchmarkWithInvoke):
                     metric_json_str = line[line.index('[function config]: ') +
                                            len('[function config]: '):].replace(' ', '').replace(':', '_')[1:-1]
                     metric_list = metric_json_str.split(',')
-                    print(metric_list)
                     for key in metric_list:
                         if 'name' in key:
                             metric = key + metric

--- a/superbench/benchmarks/micro_benchmarks/cudnn_function.py
+++ b/superbench/benchmarks/micro_benchmarks/cudnn_function.py
@@ -315,7 +315,7 @@ class CudnnBenchmark(MicroBenchmarkWithInvoke):
             }
         ]
 
-        self._bin_name = 'CudnnBenchmark'
+        self._bin_name = 'cudnn_benchmark'
 
     def add_parser_arguments(self):
         """Add the specified arguments."""
@@ -410,7 +410,16 @@ class CudnnBenchmark(MicroBenchmarkWithInvoke):
             raw_data = []
             for line in lines:
                 if '[function config]' in line:
-                    metric = line[line.index('[function config]: ') + len('[function config]: '):]
+                    metric = ''
+                    metric_json_str = line[line.index('[function config]: ') +
+                                           len('[function config]: '):].replace(' ', '').replace(':', '_')[1:-1]
+                    metric_list = metric_json_str.split(',')
+                    print(metric_list)
+                    for key in metric_list:
+                        if 'name' in key:
+                            metric = key + metric
+                        else:
+                            metric = metric + '_' + key
                 if '[raw_data]' in line:
                     raw_data = line[line.index('[raw_data]: ') + len('[raw_data]: '):]
                     raw_data = raw_data.split(',')

--- a/superbench/benchmarks/micro_benchmarks/cudnn_function/CMakeLists.txt
+++ b/superbench/benchmarks/micro_benchmarks/cudnn_function/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 cmake_minimum_required(VERSION 3.18)
-project(CudnnBenchmark LANGUAGES CUDA CXX)
+project(cudnn_benchmark LANGUAGES CUDA CXX)
 
 include(../cuda_common.cmake)
 
@@ -28,6 +28,6 @@ if(NOT json_POPULATED)
   add_subdirectory(${json_SOURCE_DIR} ${json_BINARY_DIR} EXCLUDE_FROM_ALL)
 endif()
 
-add_executable(CudnnBenchmark cudnn_test.cpp)   
-target_link_libraries(CudnnBenchmark ${TARGET_NAME} nlohmann_json::nlohmann_json CUDA::cudart ${CUDNN_LIBRARY}) 
-install(TARGETS CudnnBenchmark ${TARGET_NAME} RUNTIME DESTINATION bin LIBRARY DESTINATION lib)
+add_executable(cudnn_benchmark cudnn_test.cpp)   
+target_link_libraries(cudnn_benchmark ${TARGET_NAME} nlohmann_json::nlohmann_json CUDA::cudart ${CUDNN_LIBRARY}) 
+install(TARGETS cudnn_benchmark ${TARGET_NAME} RUNTIME DESTINATION bin LIBRARY DESTINATION lib)


### PR DESCRIPTION
**Description**
Rename bin name of cublas and cudnn microbenchmark to 'cublas_benchmark' and 'cudnn_benchmark'.
Rename metric name of cublas and cudnn microbenchmark.

