### PR TITLE
Benchmarks: Add Feature - Add DistributedImpl and DistributedBackend arguments for micro benchmark.

### DIFF
--- a/superbench/benchmarks/__init__.py
+++ b/superbench/benchmarks/__init__.py
@@ -6,7 +6,8 @@
 import importlib
 
 from superbench.benchmarks.return_code import ReturnCode
-from superbench.benchmarks.context import Platform, Framework, Precision, ModelAction, BenchmarkType, BenchmarkContext
+from superbench.benchmarks.context import Platform, Framework, Precision, ModelAction, \
+    DistributedImpl, DistributedBackend, BenchmarkType, BenchmarkContext
 from superbench.common.utils import LazyImport
 
 BenchmarkRegistry = LazyImport(
@@ -21,6 +22,6 @@ BenchmarkRegistry = LazyImport(
 )
 
 __all__ = [
-    'ReturnCode', 'Platform', 'Framework', 'BenchmarkType', 'Precision', 'ModelAction', 'BenchmarkContext',
-    'BenchmarkRegistry'
+    'ReturnCode', 'Platform', 'Framework', 'BenchmarkType', 'Precision', 'ModelAction', 'DistributedImpl',
+    'DistributedBackend', 'BenchmarkContext', 'BenchmarkRegistry'
 ]

--- a/superbench/benchmarks/context.py
+++ b/superbench/benchmarks/context.py
@@ -61,6 +61,22 @@ class ModelAction(Enum):
     INFERENCE = 'inference'
 
 
+class DistributedImpl(Enum):
+    """The Enum class representing different distributed implementations."""
+    DDP = 'ddp'
+    MIRRORED = 'mirrored'
+    MW_MIRRORED = 'multiworkermirrored'
+    PS = 'parameterserver'
+    HOROVOD = 'horovod'
+
+
+class DistributedBackend(Enum):
+    """The Enum class representing different distributed backends."""
+    NCCL = 'nccl'
+    MPI = 'mpi'
+    GLOO = 'gloo'
+
+
 class BenchmarkContext():
     """Context class of all benchmarks.
 

--- a/superbench/benchmarks/model_benchmarks/model_base.py
+++ b/superbench/benchmarks/model_benchmarks/model_base.py
@@ -8,7 +8,7 @@ import time
 from abc import abstractmethod
 
 from superbench.common.utils import logger
-from superbench.benchmarks import Precision, ModelAction, BenchmarkType, ReturnCode
+from superbench.benchmarks import Precision, ModelAction, DistributedImpl, DistributedBackend, BenchmarkType, ReturnCode
 from superbench.benchmarks.base import Benchmark
 from superbench.benchmarks.context import Enum
 
@@ -18,22 +18,6 @@ class Optimizer(Enum):
     SGD = 'sgd'
     ADAM = 'adam'
     ADAMW = 'adamw'
-
-
-class DistributedImpl(Enum):
-    """The Enum class representing different distributed implementations."""
-    DDP = 'ddp'
-    MIRRORED = 'mirrored'
-    MW_MIRRORED = 'multiworkermirrored'
-    PS = 'parameterserver'
-    HOROVOD = 'horovod'
-
-
-class DistributedBackend(Enum):
-    """The Enum class representing different distributed backends."""
-    NCCL = 'nccl'
-    MPI = 'mpi'
-    GLOO = 'gloo'
 
 
 class ModelBenchmark(Benchmark):


### PR DESCRIPTION
**Description**
For distributed micro-benchmarks, add DistributedImpl and DistributedBackend arguments. Currently the benchmark 'computation_communication_overlap' and 'sharding_matmul' need to add these arguments.


