### PR TITLE
Benchmarks: Fix bug - fix bug of third_party/cuda-samples git checkout issue when building docker

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,6 +2,3 @@
 	path = third_party/cutlass
 	url = https://github.com/NVIDIA/cutlass.git
 	branch = v2.4.0
-[submodule "third_party/cuda-samples"]
-	path = third_party/cuda-samples
-	url = https://github.com/NVIDIA/cuda-samples.git

--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -25,6 +25,8 @@ endif
 # The version we use is the released tag of cuda-samples which is consistent with the cuda version in the environment or docker.
 # The Makefile of bandwidthTest does not have 'install' target, so need to copy bin to $(SB_MICRO_PATH)/bin/ and create $(SB_MICRO_PATH)/bin/ if not existing.
 bandwidthTest: sb_micro_path
+	if [ -d cuda-samples ]; then rm -rf cuda-samples; fi
+	git clone https://github.com/NVIDIA/cuda-samples.git
 ifneq (,$(wildcard cuda-samples/Samples/bandwidthTest/Makefile))
 	cd cuda-samples && git checkout v$(shell nvcc --version | grep 'release' | awk '{print $$6}' | cut -c2- | cut -d '.' -f1-2)
 	cd ./cuda-samples/Samples/bandwidthTest && make clean && make TARGET_ARCH=x86_64 SMS="70 75 80 86"

--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -27,7 +27,5 @@ endif
 bandwidthTest: sb_micro_path
 	if [ -d cuda-samples ]; then rm -rf cuda-samples; fi
 	git clone -b v$(shell nvcc --version | grep 'release' | awk '{print $$6}' | cut -c2- | cut -d '.' -f1-2) https://github.com/NVIDIA/cuda-samples.git ./cuda-samples
-ifneq (,$(wildcard cuda-samples/Samples/bandwidthTest/Makefile))
 	cd ./cuda-samples/Samples/bandwidthTest && make clean && make TARGET_ARCH=x86_64 SMS="70 75 80 86"
 	cp -v ./cuda-samples/Samples/bandwidthTest/bandwidthTest $(SB_MICRO_PATH)/bin/
-endif

--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -26,9 +26,8 @@ endif
 # The Makefile of bandwidthTest does not have 'install' target, so need to copy bin to $(SB_MICRO_PATH)/bin/ and create $(SB_MICRO_PATH)/bin/ if not existing.
 bandwidthTest: sb_micro_path
 	if [ -d cuda-samples ]; then rm -rf cuda-samples; fi
-	git clone https://github.com/NVIDIA/cuda-samples.git
+	git clone -b v$(shell nvcc --version | grep 'release' | awk '{print $$6}' | cut -c2- | cut -d '.' -f1-2) https://github.com/NVIDIA/cuda-samples.git ./cuda-samples
 ifneq (,$(wildcard cuda-samples/Samples/bandwidthTest/Makefile))
-	cd cuda-samples && git checkout v$(shell nvcc --version | grep 'release' | awk '{print $$6}' | cut -c2- | cut -d '.' -f1-2)
 	cd ./cuda-samples/Samples/bandwidthTest && make clean && make TARGET_ARCH=x86_64 SMS="70 75 80 86"
 	cp -v ./cuda-samples/Samples/bandwidthTest/bandwidthTest $(SB_MICRO_PATH)/bin/
 endif


### PR DESCRIPTION
**Description**
There is something wrong with git submodule's checkout in makefile during docker building because previously .git was excluded when ADD or COPY which is defined in .dockerignore. 

**Major Revision**
- Remove cuda-samples in .gitmodules.
- Add git clone in third_party/makefile

