### PR TITLE
Benchmarks: Build Pipeline - Add FIO benchmark tool

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = third_party/cutlass
 	url = https://github.com/NVIDIA/cutlass.git
 	branch = v2.4.0
+[submodule "third_party/fio"]
+	path = third_party/fio
+	url = https://github.com/axboe/fio.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,4 @@
 [submodule "third_party/fio"]
 	path = third_party/fio
 	url = https://github.com/axboe/fio.git
+	branch = master

--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -17,7 +17,7 @@ sb_micro_path:
 	mkdir -p $(SB_MICRO_PATH)/lib
 
 # Build cutlass.
-cutlass: sb_micro_path
+cutlass:
 ifneq (,$(wildcard cutlass/CMakeLists.txt))
 	cmake -DCMAKE_INSTALL_BINDIR=$(SB_MICRO_PATH)/bin -DCMAKE_INSTALL_LIBDIR=$(SB_MICRO_PATH)/lib -DCMAKE_BUILD_TYPE=Release \
 		-DCUTLASS_NVCC_ARCHS='70;80' -DCUTLASS_ENABLE_EXAMPLES=OFF -DCUTLASS_ENABLE_TESTS=OFF -S ./cutlass -B ./cutlass/build
@@ -44,13 +44,13 @@ endif
 
 # Build perftest.
 # The version we use is the tag v4.5-0.2.
-perftest: sb_micro_path
+perftest:
 ifneq (,$(wildcard perftest/autogen.sh))
 	cd perftest && ./autogen.sh && ./configure CUDA_H_PATH=/usr/local/cuda/include/cuda.h --prefix=$(SB_MICRO_PATH) && make -j && make install
 endif
 
 # Build FIO from commit 0313e9 (fio-3.27 tag).
-fio: sb_micro_path
+fio:
 ifneq (,$(wildcard fio/Makefile))
 	cd ./fio && ./configure --prefix=$(SB_MICRO_PATH) && make -j && make install
 endif

--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -13,13 +13,15 @@ all: cutlass bandwidthTest fio
 sb_micro_path:
 	mkdir -p $(SB_MICRO_PATH)/bin
 	mkdir -p $(SB_MICRO_PATH)/lib
+
 # Build cutlass.
-cutlass:
+cutlass: sb_micro_path
 ifneq (,$(wildcard cutlass/CMakeLists.txt))
 	cmake -DCMAKE_INSTALL_BINDIR=$(SB_MICRO_PATH)/bin -DCMAKE_INSTALL_LIBDIR=$(SB_MICRO_PATH)/lib -DCMAKE_BUILD_TYPE=Release \
 		-DCUTLASS_NVCC_ARCHS='70;80' -DCUTLASS_ENABLE_EXAMPLES=OFF -DCUTLASS_ENABLE_TESTS=OFF -S ./cutlass -B ./cutlass/build
-	cmake --build ./cutlass/build -j 8 --target install
+	cmake --build ./cutlass/build -j --target install
 endif
+
 # Build cuda-samples/Samples/bandwidthTest.
 # cuda-samples is released together with CUDA, they have the exact same version. Like v10.0, v11.1 and so on.
 # The version we use is the released tag of cuda-samples which is consistent with the cuda version in the environment or docker.
@@ -29,8 +31,9 @@ bandwidthTest: sb_micro_path
 	git clone -b v$(shell nvcc --version | grep 'release' | awk '{print $$6}' | cut -c2- | cut -d '.' -f1-2) https://github.com/NVIDIA/cuda-samples.git ./cuda-samples
 	cd ./cuda-samples/Samples/bandwidthTest && make clean && make TARGET_ARCH=x86_64 SMS="70 75 80 86"
 	cp -v ./cuda-samples/Samples/bandwidthTest/bandwidthTest $(SB_MICRO_PATH)/bin/
+
 # Build FIO (3.27).
 fio: sb_micro_path
 ifneq (,$(wildcard fio/Makefile))
-	cd ./fio && ./configure --prefix=$(SB_MICRO_PATH) && make -j8 && make install
+	cd ./fio && ./configure --prefix=$(SB_MICRO_PATH) && make -j && make install
 endif

--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -32,8 +32,5 @@ bandwidthTest: sb_micro_path
 # Build FIO (3.27).
 fio: sb_micro_path
 ifneq (,$(wildcard fio/Makefile))
-	cd ./fio
-	./configure --prefix=$(SB_MICRO_PATH)
-	make -j
-	make install
+	cd ./fio && ./configure --prefix=$(SB_MICRO_PATH) && make -j8 && make install
 endif

--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -46,3 +46,4 @@ endif
 fio: sb_micro_path
 ifneq (,$(wildcard fio/Makefile))
 	cd ./fio && ./configure --prefix=$(SB_MICRO_PATH) && make -j && make install
+endif

--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -19,7 +19,7 @@ cutlass: sb_micro_path
 ifneq (,$(wildcard cutlass/CMakeLists.txt))
 	cmake -DCMAKE_INSTALL_BINDIR=$(SB_MICRO_PATH)/bin -DCMAKE_INSTALL_LIBDIR=$(SB_MICRO_PATH)/lib -DCMAKE_BUILD_TYPE=Release \
 		-DCUTLASS_NVCC_ARCHS='70;80' -DCUTLASS_ENABLE_EXAMPLES=OFF -DCUTLASS_ENABLE_TESTS=OFF -S ./cutlass -B ./cutlass/build
-	cmake --build ./cutlass/build -j --target install
+	cmake --build ./cutlass/build -j 8 --target install
 endif
 
 # Build cuda-samples/Samples/bandwidthTest.

--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -4,10 +4,10 @@
 
 SB_MICRO_PATH ?= "/usr/local"
 
-.PHONY: all cutlass bandwidthTest
+.PHONY: all cutlass bandwidthTest fio
 
 # Build all targets.
-all: cutlass bandwidthTest
+all: cutlass bandwidthTest fio
 
 # Create $(SB_MICRO_PATH)/bin and $(SB_MICRO_PATH)/lib, no error if existing, make parent directories as needed.
 sb_micro_path:
@@ -29,3 +29,11 @@ bandwidthTest: sb_micro_path
 	git clone -b v$(shell nvcc --version | grep 'release' | awk '{print $$6}' | cut -c2- | cut -d '.' -f1-2) https://github.com/NVIDIA/cuda-samples.git ./cuda-samples
 	cd ./cuda-samples/Samples/bandwidthTest && make clean && make TARGET_ARCH=x86_64 SMS="70 75 80 86"
 	cp -v ./cuda-samples/Samples/bandwidthTest/bandwidthTest $(SB_MICRO_PATH)/bin/
+# Build FIO (3.27).
+fio: sb_micro_path
+ifneq (,$(wildcard fio/Makefile))
+	cd ./fio
+	./configure --prefix=$(SB_MICRO_PATH)
+	make -j
+	make install
+endif

--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -34,6 +34,7 @@ bandwidthTest: sb_micro_path
 	cd ./cuda-samples/Samples/bandwidthTest && make clean && make TARGET_ARCH=x86_64 SMS="70 75 80 86"
 	cp -v ./cuda-samples/Samples/bandwidthTest/bandwidthTest $(SB_MICRO_PATH)/bin/
 
+# Build nccl-tests.
 # The version we use is commit 44df0bf from master branch, since it didn't update release tag for long time.
 nccl_tests: sb_micro_path
 ifneq (,$(wildcard nccl-tests/Makefile))
@@ -45,4 +46,3 @@ endif
 fio: sb_micro_path
 ifneq (,$(wildcard fio/Makefile))
 	cd ./fio && ./configure --prefix=$(SB_MICRO_PATH) && make -j && make install
-# Build nccl-tests.


### PR DESCRIPTION
**Description**
Add FIO benchmark tool into third-party dependency.

**Major Revision**
- Add FIO submodule into third-party directory and modify Makefile to enable it.
