### PR TITLE
Benchmarks: Fix Bug - Fix bug of VGG models failed on A100 GPU with batch_size=128

### DIFF
--- a/superbench/benchmarks/model_benchmarks/pytorch_base.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_base.py
@@ -184,11 +184,13 @@ class PytorchBase(ModelBenchmark):
             )
             return False
 
-        del self._model
-        del self._optimizer
+        if self._gpu_available:
+            torch.cuda.synchronize()
         del self._target
-
-        torch.cuda.empty_cache()
+        del self._optimizer
+        del self._model
+        if self._gpu_available:
+            torch.cuda.empty_cache()
 
         return True
 


### PR DESCRIPTION
**Description**
Fix bug of VGG models failed on A100 GPU with batch_size=128.

**Major Revision**
- Add synchronize before delete self.model in _postprocess of superbench/benchmarks/model_benchmarks/pytorch_base.py

**Minor Revision**
- Add if self._gpu_available check 
- Reorder del 


