### PR TITLE
Benchmarks: Build Pipeline - add rccl-tests as a submodule with building logic

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,3 +12,6 @@
 	path = third_party/fio
 	url = https://github.com/axboe/fio.git
 	branch = master
+[submodule "third_party/rccl-tests"]
+	path = third_party/rccl-tests
+	url = https://github.com/ROCmSoftwarePlatform/rccl-tests.git

--- a/dockerfile/cuda11.1.1.dockerfile
+++ b/dockerfile/cuda11.1.1.dockerfile
@@ -93,7 +93,7 @@ ENV PATH="${PATH}" \
 WORKDIR ${SB_HOME}
 
 ADD third_party third_party
-RUN make -j -C third_party cuda
+RUN make -j -C third_party
 
 ADD . .
 RUN python3 -m pip install .[nvidia,torch] && \

--- a/dockerfile/cuda11.1.1.dockerfile
+++ b/dockerfile/cuda11.1.1.dockerfile
@@ -93,7 +93,7 @@ ENV PATH="${PATH}" \
 WORKDIR ${SB_HOME}
 
 ADD third_party third_party
-RUN make -j -C third_party
+RUN make -j -C third_party cuda
 
 ADD . .
 RUN python3 -m pip install .[nvidia,torch] && \

--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -12,7 +12,7 @@ USE_ROCM ?= "0"
 
 .PHONY: all common cuda rocm cutlass bandwidthTest nccl_tests perftest fio rccl_tests
 
-# Build all targets for cuda.
+# Build all targets.
 all: cuda rocm
 cuda: common cutlass bandwidthTest nccl_tests
 rocm: common rccl_tests

--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -8,13 +8,10 @@ MPI_HOME_PATH ?= "/usr/local/mpi"
 HIP_HOME ?= "/opt/rocm/hip"
 RCCL_HOME ?= "/opt/rocm/rccl"
 
-.PHONY: all common cuda rocm cutlass bandwidthTest nccl_tests perftest fio rccl_tests
+.PHONY: all cutlass bandwidthTest nccl_tests perftest fio
 
 # Build all targets.
-all: cuda rocm
-cuda: common cutlass bandwidthTest nccl_tests perftest_cuda
-rocm: common rccl_tests perftest_rocm
-common: fio
+all: cutlass bandwidthTest nccl_tests perftest fio
 
 # Create $(SB_MICRO_PATH)/bin and $(SB_MICRO_PATH)/lib, no error if existing, make parent directories as needed.
 sb_micro_path:
@@ -49,13 +46,9 @@ endif
 
 # Build perftest.
 # The version we use is the tag v4.5-0.2.
-perftest_cuda:
+perftest:
 ifneq (,$(wildcard perftest/autogen.sh))
 	cd perftest && ./autogen.sh && ./configure CUDA_H_PATH=/usr/local/cuda/include/cuda.h --prefix=$(SB_MICRO_PATH) && make -j && make install
-endif
-perftest_rocm:
-ifneq (,$(wildcard perftest/autogen.sh))
-	cd perftest && ./autogen.sh && ./configure --enable-rocm --with-rocm=/opt/rocm --prefix=$(SB_MICRO_PATH) && make -j && make install
 endif
 
 # Build FIO from commit 0313e9 (fio-3.27 tag).

--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -5,11 +5,18 @@
 
 SB_MICRO_PATH ?= "/usr/local"
 MPI_HOME_PATH ?= "/usr/local/mpi"
+HIP_HOME ?= "/opt/rocm/hip"
+RCCL_HOME ?= "/opt/rocm/rccl"
+USE_CUDA ?= "1"
+USE_ROCM ?= "0"
 
-.PHONY: all cutlass bandwidthTest nccl_tests perftest fio
+.PHONY: all common cuda rocm cutlass bandwidthTest nccl_tests perftest fio rccl_tests
 
-# Build all targets.
-all: cutlass bandwidthTest nccl_tests perftest fio
+# Build all targets for cuda.
+all: cuda rocm
+cuda: common cutlass bandwidthTest nccl_tests
+rocm: common rccl_tests
+common: perftest fio
 
 # Create $(SB_MICRO_PATH)/bin and $(SB_MICRO_PATH)/lib, no error if existing, make parent directories as needed.
 sb_micro_path:
@@ -46,11 +53,24 @@ endif
 # The version we use is the tag v4.5-0.2.
 perftest:
 ifneq (,$(wildcard perftest/autogen.sh))
+ifeq (1,$(USE_CUDA))
 	cd perftest && ./autogen.sh && ./configure CUDA_H_PATH=/usr/local/cuda/include/cuda.h --prefix=$(SB_MICRO_PATH) && make -j && make install
+else ifeq (1,$(USE_ROCM))
+	cd perftest && ./autogen.sh && ./configure --enable-rocm --with-rocm=/opt/rocm --prefix=$(SB_MICRO_PATH) && make -j && make install
+else
+	cd perftest && ./autogen.sh && ./configure --prefix=$(SB_MICRO_PATH) && make -j && make install
+endif
 endif
 
 # Build FIO from commit 0313e9 (fio-3.27 tag).
 fio:
 ifneq (,$(wildcard fio/Makefile))
 	cd ./fio && ./configure --prefix=$(SB_MICRO_PATH) && make -j && make install
+endif
+
+# Build rccl-tests from commit cc34c5 of develop branch (default branch).
+rccl_tests: sb_micro_path
+ifneq (, $(wildcard rccl-tests/Makefile))
+	cd ./rccl-tests && make MPI=1 MPI_HOME=$(MPI_HOME_PATH) HIP_HOME=$(HIP_HOME) RCCL_HOME=$(RCCL_HOME) -j
+	cp -v ./rccl-tests/build/* $(SB_MICRO_PATH)/bin/
 endif

--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -7,16 +7,14 @@ SB_MICRO_PATH ?= "/usr/local"
 MPI_HOME_PATH ?= "/usr/local/mpi"
 HIP_HOME ?= "/opt/rocm/hip"
 RCCL_HOME ?= "/opt/rocm/rccl"
-USE_CUDA ?= "1"
-USE_ROCM ?= "0"
 
 .PHONY: all common cuda rocm cutlass bandwidthTest nccl_tests perftest fio rccl_tests
 
 # Build all targets.
 all: cuda rocm
-cuda: common cutlass bandwidthTest nccl_tests
-rocm: common rccl_tests
-common: perftest fio
+cuda: common cutlass bandwidthTest nccl_tests perftest_cuda
+rocm: common rccl_tests perftest_rocm
+common: fio
 
 # Create $(SB_MICRO_PATH)/bin and $(SB_MICRO_PATH)/lib, no error if existing, make parent directories as needed.
 sb_micro_path:
@@ -51,15 +49,13 @@ endif
 
 # Build perftest.
 # The version we use is the tag v4.5-0.2.
-perftest:
+perftest_cuda:
 ifneq (,$(wildcard perftest/autogen.sh))
-ifeq (1,$(USE_CUDA))
 	cd perftest && ./autogen.sh && ./configure CUDA_H_PATH=/usr/local/cuda/include/cuda.h --prefix=$(SB_MICRO_PATH) && make -j && make install
-else ifeq (1,$(USE_ROCM))
-	cd perftest && ./autogen.sh && ./configure --enable-rocm --with-rocm=/opt/rocm --prefix=$(SB_MICRO_PATH) && make -j && make install
-else
-	cd perftest && ./autogen.sh && ./configure --prefix=$(SB_MICRO_PATH) && make -j && make install
 endif
+perftest_rocm:
+ifneq (,$(wildcard perftest/autogen.sh))
+	cd perftest && ./autogen.sh && ./configure --enable-rocm --with-rocm=/opt/rocm --prefix=$(SB_MICRO_PATH) && make -j && make install
 endif
 
 # Build FIO from commit 0313e9 (fio-3.27 tag).

--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -3,17 +3,17 @@
 # Licensed under the MIT License
 
 
-SB_MICRO_PATH ?= "/usr/local"
-MPI_HOME_PATH ?= "/usr/local/mpi"
-HIP_HOME ?= "/opt/rocm/hip"
-RCCL_HOME ?= "/opt/rocm/rccl"
+SB_MICRO_PATH ?= /usr/local
+MPI_HOME ?= /usr/local/mpi
+HIP_HOME ?= /opt/rocm/hip
+RCCL_HOME ?= /opt/rocm/rccl
 
-.PHONY: all cuda rocm common cuda_cutlass cuda_bandwidthTest cuda_nccl_tests cuda_perftest rocm_perftest fio
+.PHONY: all cuda rocm common cuda_cutlass cuda_bandwidthTest cuda_nccl_tests cuda_perftest rocm_perftest fio rocm_rccl_tests
 
 # Build all targets.
 all: cuda rocm
 cuda: common cuda_cutlass cuda_bandwidthTest cuda_nccl_tests cuda_perftest
-rocm: common rocm_perftest
+rocm: common rocm_perftest rocm_rccl_tests
 common: fio
 
 # Create $(SB_MICRO_PATH)/bin and $(SB_MICRO_PATH)/lib, no error if existing, make parent directories as needed.
@@ -43,7 +43,7 @@ cuda_bandwidthTest: sb_micro_path
 # The version we use is commit 44df0bf from master branch, since it didn't update release tag for long time.
 cuda_nccl_tests: sb_micro_path
 ifneq (,$(wildcard nccl-tests/Makefile))
-	cd ./nccl-tests && make MPI=1 MPI_HOME=$(MPI_HOME_PATH) -j
+	cd ./nccl-tests && make MPI=1 MPI_HOME=$(MPI_HOME) -j
 	cp -v ./nccl-tests/build/* $(SB_MICRO_PATH)/bin/
 endif
 
@@ -65,8 +65,8 @@ ifneq (,$(wildcard fio/Makefile))
 endif
 
 # Build rccl-tests from commit cc34c5 of develop branch (default branch).
-rccl_tests: sb_micro_path
+rocm_rccl_tests: sb_micro_path
 ifneq (, $(wildcard rccl-tests/Makefile))
-	cd ./rccl-tests && make MPI=1 MPI_HOME=$(MPI_HOME_PATH) HIP_HOME=$(HIP_HOME) RCCL_HOME=$(RCCL_HOME) -j
+	cd ./rccl-tests && make MPI=1 MPI_HOME=$(MPI_HOME) HIP_HOME=$(HIP_HOME) RCCL_HOME=$(RCCL_HOME) -j
 	cp -v ./rccl-tests/build/* $(SB_MICRO_PATH)/bin/
 endif


### PR DESCRIPTION
**Description**
Support rocm in third_party/makefile and add rccl-tests as a submodule with building logic.

**Major Revision**
- Support rocm in third_party/makefile
- Add rccl-tests as a submodule 
- Add build logic in third_party/Makefile for rccl-tests 