### PR TITLE
Benchmarks: Revise Benchmark - Add readwrite I/O pattern

### DIFF
--- a/superbench/benchmarks/micro_benchmarks/disk_performance.py
+++ b/superbench/benchmarks/micro_benchmarks/disk_performance.py
@@ -26,7 +26,7 @@ class DiskBenchmark(MicroBenchmarkWithInvoke):
         self._bin_name = 'fio'
 
         self.__io_patterns = ['seq', 'rand']
-        self.__io_types = ['read', 'write', 'rw']
+        self.__io_types = ['read', 'write', 'readwrite']
         self.__rand_block_size = 4 * 1024    # 4KiB
         self.__seq_block_size = 128 * 1024    # 128KiB
         self.__default_iodepth = 64
@@ -55,11 +55,13 @@ class DiskBenchmark(MicroBenchmarkWithInvoke):
         for io_pattern in self.__io_patterns:
             for io_type in self.__io_types:
                 io_str = '%s_%s' % (io_pattern, io_type)
-                fio_rw = io_type if io_pattern == 'seq' else io_pattern + io_type
+                # Convert readwrite to rw for FIO
+                fio_io_type = 'rw' if io_type == 'readwrite' else io_type
+                fio_rw = fio_io_type if io_pattern == 'seq' else io_pattern + fio_io_type
                 fio_bs = self.__seq_block_size if io_pattern == 'seq' else self.__rand_block_size
                 self.__fio_args[io_str] = self.__common_fio_args +\
                     ' --name=%s --rw=%s --bs=%d --time_based=1' % (io_str, fio_rw, fio_bs)
-                if io_type == 'rw':
+                if fio_io_type == 'rw':
                     self.__fio_args[io_str] += ' --rwmixread=%d' % self.__default_rwmixread
 
     def add_parser_arguments(self):
@@ -100,7 +102,7 @@ class DiskBenchmark(MicroBenchmarkWithInvoke):
                     help='Time in seconds to warm up %s test.' % io_str,
                 )
                 # Disable write tests by default
-                default_runtime = 0 if io_type in ['write', 'rw'] else self.__default_runtime
+                default_runtime = 0 if 'write' in io_type else self.__default_runtime
                 self._parser.add_argument(
                     '--%s_runtime' % io_str,
                     type=int,

--- a/superbench/benchmarks/micro_benchmarks/disk_performance.py
+++ b/superbench/benchmarks/micro_benchmarks/disk_performance.py
@@ -100,7 +100,7 @@ class DiskBenchmark(MicroBenchmarkWithInvoke):
                     help='Time in seconds to warm up %s test.' % io_str,
                 )
                 # Disable write tests by default
-                default_runtime = 0 if io_type == 'write' else self.__default_runtime
+                default_runtime = 0 if io_type in ['write', 'rw'] else self.__default_runtime
                 self._parser.add_argument(
                     '--%s_runtime' % io_str,
                     type=int,

--- a/superbench/benchmarks/micro_benchmarks/disk_performance.py
+++ b/superbench/benchmarks/micro_benchmarks/disk_performance.py
@@ -26,13 +26,14 @@ class DiskBenchmark(MicroBenchmarkWithInvoke):
         self._bin_name = 'fio'
 
         self.__io_patterns = ['seq', 'rand']
-        self.__io_types = ['read', 'write']
+        self.__io_types = ['read', 'write', 'rw']
         self.__rand_block_size = 4 * 1024    # 4KiB
         self.__seq_block_size = 128 * 1024    # 128KiB
         self.__default_iodepth = 64
         self.__default_ramp_time = 10
         self.__default_runtime = 60
         self.__default_numjobs_for_rand = 4
+        self.__default_rwmixread = 80
 
         self.__common_fio_args =\
             ' --randrepeat=1 --thread=1 --ioengine=libaio --direct=1'\
@@ -58,6 +59,8 @@ class DiskBenchmark(MicroBenchmarkWithInvoke):
                 fio_bs = self.__seq_block_size if io_pattern == 'seq' else self.__rand_block_size
                 self.__fio_args[io_str] = self.__common_fio_args +\
                     ' --name=%s --rw=%s --bs=%d --time_based=1' % (io_str, fio_rw, fio_bs)
+                if io_type == 'rw':
+                    self.__fio_args[io_str] += ' --rwmixread=%d' % self.__default_rwmixread
 
     def add_parser_arguments(self):
         """Add the specified arguments."""

--- a/tests/benchmarks/micro_benchmarks/test_disk_performance.py
+++ b/tests/benchmarks/micro_benchmarks/test_disk_performance.py
@@ -122,7 +122,7 @@ class DiskBenchmarkTest(unittest.TestCase):
         curr_test_magic += 1
         # Seq/rand read/write
         for io_pattern in ['seq', 'rand']:
-            for io_type in ['read', 'write', 'rw']:
+            for io_type in ['read', 'write', 'readwrite']:
                 io_str = '%s_%s' % (io_pattern, io_type)
                 param_str += ' --%s_ramp_time=%d' % (io_str, curr_test_magic)
                 curr_test_magic += 1

--- a/tests/benchmarks/micro_benchmarks/test_disk_performance.py
+++ b/tests/benchmarks/micro_benchmarks/test_disk_performance.py
@@ -85,9 +85,7 @@ class DiskBenchmarkTest(unittest.TestCase):
         param_str = block_device_option
         param_str += ' --rand_precond_time=0'
         param_str += ' --seq_read_runtime=0'
-        param_str += ' --seq_write_runtime=0'
         param_str += ' --rand_read_runtime=0'
-        param_str += ' --rand_write_runtime=0'
         benchmark = benchmark_class(benchmark_name, parameters=param_str)
 
         # Check basic information

--- a/tests/benchmarks/micro_benchmarks/test_disk_performance.py
+++ b/tests/benchmarks/micro_benchmarks/test_disk_performance.py
@@ -124,7 +124,7 @@ class DiskBenchmarkTest(unittest.TestCase):
         curr_test_magic += 1
         # Seq/rand read/write
         for io_pattern in ['seq', 'rand']:
-            for io_type in ['read', 'write']:
+            for io_type in ['read', 'write', 'rw']:
                 io_str = '%s_%s' % (io_pattern, io_type)
                 param_str += ' --%s_ramp_time=%d' % (io_str, curr_test_magic)
                 curr_test_magic += 1
@@ -164,7 +164,7 @@ class DiskBenchmarkTest(unittest.TestCase):
             command_idx += 1
             # Seq/rand read/write
             for io_pattern in ['seq', 'rand']:
-                for io_type in ['read', 'write']:
+                for io_type in ['read', 'write', 'rw']:
                     assert ('--filename=%s' % block_device in benchmark._commands[command_idx])
                     fio_rw = '%s%s' % (io_pattern if io_pattern == 'rand' else '', io_type)
                     assert ('--rw=%s' % fio_rw in benchmark._commands[command_idx])
@@ -176,6 +176,8 @@ class DiskBenchmarkTest(unittest.TestCase):
                     curr_test_magic += 1
                     assert ('--numjobs=%d' % curr_test_magic in benchmark._commands[command_idx])
                     curr_test_magic += 1
+                    if io_type == 'rw':
+                        assert ('--rwmixread=%d' % benchmark.__default_rwmixread in benchmark._commands[command_idx])
                     command_idx += 1
 
     def test_disk_performance_result_parsing(self):

--- a/tests/benchmarks/micro_benchmarks/test_disk_performance.py
+++ b/tests/benchmarks/micro_benchmarks/test_disk_performance.py
@@ -145,8 +145,8 @@ class DiskBenchmarkTest(unittest.TestCase):
         assert (benchmark.type == BenchmarkType.MICRO)
 
         # Check command list
-        # 2 files * (2 preconditions + 2 io_patterns * 2 io_types) = 12 commands
-        assert (12 == len(benchmark._commands))
+        # 2 files * (2 preconditions + 3 io_patterns * 2 io_types) = 16 commands
+        assert (16 == len(benchmark._commands))
 
         # Check parameter assignments
         command_idx = 0

--- a/tests/benchmarks/micro_benchmarks/test_disk_performance.py
+++ b/tests/benchmarks/micro_benchmarks/test_disk_performance.py
@@ -150,7 +150,7 @@ class DiskBenchmarkTest(unittest.TestCase):
 
         # Check parameter assignments
         command_idx = 0
-
+        default_rwmixread = 80
         for block_device in block_devices:
             curr_test_magic = init_test_magic
 
@@ -177,7 +177,7 @@ class DiskBenchmarkTest(unittest.TestCase):
                     assert ('--numjobs=%d' % curr_test_magic in benchmark._commands[command_idx])
                     curr_test_magic += 1
                     if io_type == 'rw':
-                        assert ('--rwmixread=%d' % benchmark.__default_rwmixread in benchmark._commands[command_idx])
+                        assert ('--rwmixread=%d' % default_rwmixread in benchmark._commands[command_idx])
                     command_idx += 1
 
     def test_disk_performance_result_parsing(self):


### PR DESCRIPTION
**Description**
This commit adds readwrite I/O pattern for FIO benchmark. Read/write ratio is fixed at 4:1.