### PR TITLE
Benchmarks: Code Revision - Rename computation_communication_overlap microbenchmark metric 

### DIFF
--- a/superbench/benchmarks/micro_benchmarks/computation_communication_overlap.py
+++ b/superbench/benchmarks/micro_benchmarks/computation_communication_overlap.py
@@ -237,7 +237,7 @@ class ComputationCommunicationOverlap(MicroBenchmark):
             compute_end = time.perf_counter()
             torch.cuda.synchronize()
 
-            compute_metric = 'gpu{}_computation_cost_{}'.format(self.__local_rank, kernel)
+            compute_metric = '{}_cost'.format(kernel)
             compute_elapse_times = [(compute_end - start) * 1000 / self._args.num_steps]
 
             if not self._process_numeric_result(compute_metric, compute_elapse_times):


### PR DESCRIPTION
**Description**
Rename computation_communication_overlap microbenchmark metric .

**Major Revision**
- remove rank info in metric.
- simplify and rename metric.
