### PR TITLE
Benchmarks: Fix Bug - Remove ib device port info in command to fix bug of ib loopback 

### DIFF
--- a/superbench/benchmarks/micro_benchmarks/ib_loopback_performance.py
+++ b/superbench/benchmarks/micro_benchmarks/ib_loopback_performance.py
@@ -164,7 +164,7 @@ class IBLoopbackBenchmark(MicroBenchmarkWithInvoke):
                     command += ' ' + self.__support_ib_commands[ib_command]
                     command += command_mode + ' -F'
                     command += ' --iters=' + str(self._args.iters)
-                    command += ' -d ' + network.get_ib_devices()[self._args.ib_index]
+                    command += ' -d ' + network.get_ib_devices()[self._args.ib_index].split(':')[0]
                     command += ' -p ' + str(network.get_free_port())
                     command += ' -x ' + str(self._args.gid_index)
                     self._commands.append(command)


### PR DESCRIPTION
**Description**
Remove ib device port info in command to fix bug of ib loopback.

**Major Revision**
- Remove ib device port info in command to fix bug of ib loopback 