### PR TITLE
Benchmarks: Code Revision - Revise metric name generation and default config for disk performance benchmark

### DIFF
--- a/superbench/benchmarks/micro_benchmarks/disk_performance.py
+++ b/superbench/benchmarks/micro_benchmarks/disk_performance.py
@@ -204,7 +204,7 @@ class DiskBenchmark(MicroBenchmarkWithInvoke):
                 self._result.add_result('%s_iops' % io_type_prefix, float(iops))
 
                 for lat_unit in lat_units:
-                    if lat_unit in fio_output['jobs'][0][io_type]_
+                    if lat_unit in fio_output['jobs'][0][io_type]:
                         lat_unit_prefix = '%s_%s' % (io_type_prefix, lat_unit)
                         for lat_percentile in ['95.000000', '99.000000', '99.900000']:
                             lat = fio_output['jobs'][0][io_type][lat_unit]['percentile'][lat_percentile]

--- a/superbench/benchmarks/micro_benchmarks/disk_performance.py
+++ b/superbench/benchmarks/micro_benchmarks/disk_performance.py
@@ -191,24 +191,24 @@ class DiskBenchmark(MicroBenchmarkWithInvoke):
 
             jobname = fio_output['jobs'][0]['jobname']
             block_device = fio_output['global options']['filename']
-            jobname_prefix = 'disk_performance:%s:%s' % (block_device, jobname)
+            jobname_prefix = '%s_%s' % (block_device, jobname)
             lat_units = ['lat_ns', 'lat_us', 'lat_ms']
 
             bs = fio_output['jobs'][0]['job options']['bs']
-            self._result.add_result('%s:bs' % jobname_prefix, float(bs))
+            self._result.add_result('%s_bs' % jobname_prefix, float(bs))
 
             for io_type in ['read', 'write']:
-                io_type_prefix = '%s:%s' % (jobname_prefix, io_type)
+                io_type_prefix = '%s_%s' % (jobname_prefix, io_type)
 
                 iops = fio_output['jobs'][0][io_type]['iops']
-                self._result.add_result('%s:iops' % io_type_prefix, float(iops))
+                self._result.add_result('%s_iops' % io_type_prefix, float(iops))
 
                 for lat_unit in lat_units:
-                    if lat_unit in fio_output['jobs'][0][io_type]:
-                        lat_unit_prefix = '%s:%s' % (io_type_prefix, lat_unit)
+                    if lat_unit in fio_output['jobs'][0][io_type]_
+                        lat_unit_prefix = '%s_%s' % (io_type_prefix, lat_unit)
                         for lat_percentile in ['95.000000', '99.000000', '99.900000']:
                             lat = fio_output['jobs'][0][io_type][lat_unit]['percentile'][lat_percentile]
-                            self._result.add_result('%s:%s' % (lat_unit_prefix, lat_percentile), float(lat))
+                            self._result.add_result('%s_%s' % (lat_unit_prefix, lat_percentile), float(lat))
                         break
         except BaseException as e:
             self._result.set_return_code(ReturnCode.MICROBENCHMARK_RESULT_PARSING_FAILURE)

--- a/superbench/benchmarks/micro_benchmarks/disk_performance.py
+++ b/superbench/benchmarks/micro_benchmarks/disk_performance.py
@@ -190,7 +190,7 @@ class DiskBenchmark(MicroBenchmarkWithInvoke):
             fio_output = json.loads(raw_output)
 
             jobname = fio_output['jobs'][0]['jobname']
-            block_device = fio_output['global options']['filename']
+            block_device = os.path.basename(fio_output['global options']['filename'])
             jobname_prefix = '%s_%s' % (block_device, jobname)
             lat_units = ['lat_ns', 'lat_us', 'lat_ms']
 

--- a/superbench/config/default.yaml
+++ b/superbench/config/default.yaml
@@ -47,7 +47,8 @@ superbench:
     disk-benchmark:
       enable: false
       modes:
-        - proc_num: 1
+        - name: local
+          proc_num: 1
           parallel: no
       parameters:
         block_devices:

--- a/tests/benchmarks/micro_benchmarks/test_disk_performance.py
+++ b/tests/benchmarks/micro_benchmarks/test_disk_performance.py
@@ -504,7 +504,7 @@ class DiskBenchmarkTest(unittest.TestCase):
   ]
 }
 """
-        jobname_prefix = '/dev/nvme0n1_rand_read_write'
+        jobname_prefix = 'nvme0n1_rand_read_write'
         assert (benchmark._process_raw_result(0, test_raw_output))
         assert (benchmark.return_code == ReturnCode.SUCCESS)
 

--- a/tests/benchmarks/micro_benchmarks/test_disk_performance.py
+++ b/tests/benchmarks/micro_benchmarks/test_disk_performance.py
@@ -504,34 +504,34 @@ class DiskBenchmarkTest(unittest.TestCase):
   ]
 }
 """
-        jobname_prefix = 'disk_performance:/dev/nvme0n1:rand_read_write'
+        jobname_prefix = '/dev/nvme0n1_rand_read_write'
         assert (benchmark._process_raw_result(0, test_raw_output))
         assert (benchmark.return_code == ReturnCode.SUCCESS)
 
         # bs + <read, write> x <iops, 95th, 99th, 99.9th>
         assert (9 == len(benchmark.result.keys()))
 
-        assert (1 == len(benchmark.result[jobname_prefix + ':bs']))
-        assert (4096 == benchmark.result[jobname_prefix + ':bs'][0])
+        assert (1 == len(benchmark.result[jobname_prefix + '_bs']))
+        assert (4096 == benchmark.result[jobname_prefix + '_bs'][0])
 
-        assert (1 == len(benchmark.result[jobname_prefix + ':read:iops']))
-        assert (85138.890741 == benchmark.result[jobname_prefix + ':read:iops'][0])
-        assert (1 == len(benchmark.result[jobname_prefix + ':write:iops']))
-        assert (85066.128925 == benchmark.result[jobname_prefix + ':write:iops'][0])
+        assert (1 == len(benchmark.result[jobname_prefix + '_read_iops']))
+        assert (85138.890741 == benchmark.result[jobname_prefix + '_read_iops'][0])
+        assert (1 == len(benchmark.result[jobname_prefix + '_write_iops']))
+        assert (85066.128925 == benchmark.result[jobname_prefix + '_write_iops'][0])
 
-        assert (1 == len(benchmark.result[jobname_prefix + ':read:lat_ns:95.000000']))
-        assert (1941504 == benchmark.result[jobname_prefix + ':read:lat_ns:95.000000'][0])
-        assert (1 == len(benchmark.result[jobname_prefix + ':read:lat_ns:99.000000']))
-        assert (2244608 == benchmark.result[jobname_prefix + ':read:lat_ns:99.000000'][0])
-        assert (1 == len(benchmark.result[jobname_prefix + ':read:lat_ns:99.900000']))
-        assert (3620864 == benchmark.result[jobname_prefix + ':read:lat_ns:99.900000'][0])
+        assert (1 == len(benchmark.result[jobname_prefix + '_read_lat_ns_95.000000']))
+        assert (1941504 == benchmark.result[jobname_prefix + '_read_lat_ns_95.000000'][0])
+        assert (1 == len(benchmark.result[jobname_prefix + '_read_lat_ns_99.000000']))
+        assert (2244608 == benchmark.result[jobname_prefix + '_read_lat_ns_99.000000'][0])
+        assert (1 == len(benchmark.result[jobname_prefix + '_read_lat_ns_99.900000']))
+        assert (3620864 == benchmark.result[jobname_prefix + '_read_lat_ns_99.900000'][0])
 
-        assert (1 == len(benchmark.result[jobname_prefix + ':write:lat_ns:95.000000']))
-        assert (1908736 == benchmark.result[jobname_prefix + ':write:lat_ns:95.000000'][0])
-        assert (1 == len(benchmark.result[jobname_prefix + ':write:lat_ns:99.000000']))
-        assert (2072576 == benchmark.result[jobname_prefix + ':write:lat_ns:99.000000'][0])
-        assert (1 == len(benchmark.result[jobname_prefix + ':write:lat_ns:99.900000']))
-        assert (2605056 == benchmark.result[jobname_prefix + ':write:lat_ns:99.900000'][0])
+        assert (1 == len(benchmark.result[jobname_prefix + '_write_lat_ns_95.000000']))
+        assert (1908736 == benchmark.result[jobname_prefix + '_write_lat_ns_95.000000'][0])
+        assert (1 == len(benchmark.result[jobname_prefix + '_write_lat_ns_99.000000']))
+        assert (2072576 == benchmark.result[jobname_prefix + '_write_lat_ns_99.000000'][0])
+        assert (1 == len(benchmark.result[jobname_prefix + '_write_lat_ns_99.900000']))
+        assert (2605056 == benchmark.result[jobname_prefix + '_write_lat_ns_99.900000'][0])
 
         # Negative case - invalid raw output.
         assert (benchmark._process_raw_result(1, 'Invalid raw output') is False)


### PR DESCRIPTION
**Description**
This commit revises disk performance benchmark, including:
1) Add missing benchmark name in default config;
2) Avoid using reserved character ':' in metric name.