### PR TITLE
Benchmarks: Fix bug - Fix missing key error in disk performance benchmark

### DIFF
--- a/superbench/benchmarks/micro_benchmarks/disk_performance.py
+++ b/superbench/benchmarks/micro_benchmarks/disk_performance.py
@@ -204,7 +204,8 @@ class DiskBenchmark(MicroBenchmarkWithInvoke):
                 self._result.add_result('%s_iops' % io_type_prefix, float(iops))
 
                 for lat_unit in lat_units:
-                    if lat_unit in fio_output['jobs'][0][io_type] and 'percentile' in fio_output['jobs'][0][io_type][lat_unit]:
+                    if lat_unit in fio_output['jobs'][0][io_type] and 'percentile' in fio_output['jobs'][0][io_type][
+                        lat_unit]:
                         lat_unit_prefix = '%s_%s' % (io_type_prefix, lat_unit)
                         for lat_percentile in ['95.000000', '99.000000', '99.900000']:
                             lat = fio_output['jobs'][0][io_type][lat_unit]['percentile'][lat_percentile]

--- a/superbench/benchmarks/micro_benchmarks/disk_performance.py
+++ b/superbench/benchmarks/micro_benchmarks/disk_performance.py
@@ -204,7 +204,7 @@ class DiskBenchmark(MicroBenchmarkWithInvoke):
                 self._result.add_result('%s_iops' % io_type_prefix, float(iops))
 
                 for lat_unit in lat_units:
-                    if lat_unit in fio_output['jobs'][0][io_type]:
+                    if lat_unit in fio_output['jobs'][0][io_type] and 'percentile' in fio_output['jobs'][0][io_type][lat_unit]:
                         lat_unit_prefix = '%s_%s' % (io_type_prefix, lat_unit)
                         for lat_percentile in ['95.000000', '99.000000', '99.900000']:
                             lat = fio_output['jobs'][0][io_type][lat_unit]['percentile'][lat_percentile]

--- a/superbench/benchmarks/micro_benchmarks/disk_performance.py
+++ b/superbench/benchmarks/micro_benchmarks/disk_performance.py
@@ -204,8 +204,8 @@ class DiskBenchmark(MicroBenchmarkWithInvoke):
                 self._result.add_result('%s_iops' % io_type_prefix, float(iops))
 
                 for lat_unit in lat_units:
-                    if lat_unit in fio_output['jobs'][0][io_type] and 'percentile' in fio_output['jobs'][0][io_type][
-                        lat_unit]:
+                    if lat_unit in fio_output['jobs'][0][io_type] and \
+                       'percentile' in fio_output['jobs'][0][io_type][lat_unit]:
                         lat_unit_prefix = '%s_%s' % (io_type_prefix, lat_unit)
                         for lat_percentile in ['95.000000', '99.000000', '99.900000']:
                             lat = fio_output['jobs'][0][io_type][lat_unit]['percentile'][lat_percentile]


### PR DESCRIPTION
**Description**
This commit fixes error of missing key 'percentile' in parsing FIO result.