### PR TITLE
Benchmarks: Code Revision - Revise CMake files for microbenchmarks.

### DIFF
--- a/superbench/benchmarks/build.sh
+++ b/superbench/benchmarks/build.sh
@@ -13,6 +13,7 @@ for dir in micro_benchmarks/*/ ; do
         BUILD_ROOT=$dir/build
         mkdir -p $BUILD_ROOT
         cmake -DCMAKE_INSTALL_PREFIX=$SB_MICRO_PATH -DCMAKE_BUILD_TYPE=Release -S $SOURCE_DIR -B $BUILD_ROOT
-        cmake --build $BUILD_ROOT --target install
+        cmake --build $BUILD_ROOT
+        cmake --install $BUILD_ROOT
     fi
 done

--- a/superbench/benchmarks/build.sh
+++ b/superbench/benchmarks/build.sh
@@ -3,6 +3,7 @@
 # Copyright (c) Microsoft Corporation - All rights reserved
 # Licensed under the MIT License
 
+set -e
 
 SB_MICRO_PATH="${SB_MICRO_PATH:-/usr/local}"
 

--- a/superbench/benchmarks/micro_benchmarks/cublas_function/CMakeLists.txt
+++ b/superbench/benchmarks/micro_benchmarks/cublas_function/CMakeLists.txt
@@ -4,9 +4,9 @@
 cmake_minimum_required(VERSION 3.18)
 project(cublas_benchmark LANGUAGES CXX)
 
-include(../cuda_common.cmake)
 find_package(CUDAToolkit QUIET)
 if(CUDAToolkit_FOUND)
+  include(../cuda_common.cmake)
   set(SRC "cublas_helper.cpp" CACHE STRING "source file")
   set(TARGET_NAME "cublas_function" CACHE STRING "target name")
 
@@ -25,8 +25,8 @@ if(CUDAToolkit_FOUND)
     add_subdirectory(${json_SOURCE_DIR} ${json_BINARY_DIR} EXCLUDE_FROM_ALL)
   endif()
 
-  add_executable(cublas_benchmark cublas_test.cpp)   
-  target_link_libraries(cublas_benchmark ${TARGET_NAME} nlohmann_json::nlohmann_json CUDA::cudart CUDA::cublas) 
+  add_executable(cublas_benchmark cublas_test.cpp)
+  target_link_libraries(cublas_benchmark ${TARGET_NAME} nlohmann_json::nlohmann_json CUDA::cudart CUDA::cublas)
 
   install(TARGETS cublas_benchmark ${TARGET_NAME} RUNTIME DESTINATION bin LIBRARY DESTINATION lib)
 endif()

--- a/superbench/benchmarks/micro_benchmarks/cuda_common.cmake
+++ b/superbench/benchmarks/micro_benchmarks/cuda_common.cmake
@@ -1,10 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-if(NOT DEFINED CMAKE_CUDA_STANDARD)
-    set(CMAKE_CUDA_STANDARD 11)
-    set(CMAKE_CUDA_STANDARD_REQUIRED ON)
-endif()
+enable_language(CUDA)
 
 if(NOT DEFINED NVCC_ARCHS_SUPPORTED)
     # Reference: https://github.com/NVIDIA/cutlass/blob/0e137486498a52954eff239d874ee27ab23358e7/CMakeLists.txt#L89

--- a/superbench/benchmarks/micro_benchmarks/cuda_common.cmake
+++ b/superbench/benchmarks/micro_benchmarks/cuda_common.cmake
@@ -1,6 +1,11 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+if(NOT DEFINED CMAKE_CUDA_STANDARD)
+    set(CMAKE_CUDA_STANDARD 11)
+    set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+endif()
+
 enable_language(CUDA)
 
 if(NOT DEFINED NVCC_ARCHS_SUPPORTED)

--- a/superbench/benchmarks/micro_benchmarks/cudnn_function/CMakeLists.txt
+++ b/superbench/benchmarks/micro_benchmarks/cudnn_function/CMakeLists.txt
@@ -4,9 +4,9 @@
 cmake_minimum_required(VERSION 3.18)
 project(cudnn_benchmark LANGUAGES CXX)
 
-include(../cuda_common.cmake)
 find_package(CUDAToolkit QUIET)
 if(CUDAToolkit_FOUND)
+  include(../cuda_common.cmake)
   set(SRC "cudnn_helper.cpp" CACHE STRING "source file")
   set(TARGET_NAME "cudnn_function" CACHE STRING "target name")
 
@@ -28,7 +28,7 @@ if(CUDAToolkit_FOUND)
     add_subdirectory(${json_SOURCE_DIR} ${json_BINARY_DIR} EXCLUDE_FROM_ALL)
   endif()
 
-  add_executable(cudnn_benchmark cudnn_test.cpp)   
-  target_link_libraries(cudnn_benchmark ${TARGET_NAME} nlohmann_json::nlohmann_json CUDA::cudart ${CUDNN_LIBRARY}) 
+  add_executable(cudnn_benchmark cudnn_test.cpp)
+  target_link_libraries(cudnn_benchmark ${TARGET_NAME} nlohmann_json::nlohmann_json CUDA::cudart ${CUDNN_LIBRARY})
   install(TARGETS cudnn_benchmark ${TARGET_NAME} RUNTIME DESTINATION bin LIBRARY DESTINATION lib)
 endif()

--- a/superbench/benchmarks/micro_benchmarks/gpu_sm_copy_performance/CMakeLists.txt
+++ b/superbench/benchmarks/micro_benchmarks/gpu_sm_copy_performance/CMakeLists.txt
@@ -5,34 +5,34 @@ cmake_minimum_required(VERSION 3.18)
 
 project(gpu_sm_copy LANGUAGES CXX)
 
-include(../cuda_common.cmake)
 find_package(CUDAToolkit QUIET)
-include(../rocm_common.cmake)
-find_package(HIP QUIET)
 
 # Cuda environment
 if(CUDAToolkit_FOUND)
     message(STATUS "Found CUDA: " ${CUDAToolkit_VERSION})
 
+    include(../cuda_common.cmake)
     add_executable(gpu_sm_copy gpu_sm_copy.cu)
     set_property(TARGET gpu_sm_copy PROPERTY CUDA_ARCHITECTURES ${NVCC_ARCHS_SUPPORTED})
     install(TARGETS gpu_sm_copy RUNTIME DESTINATION bin)
-
-# ROCm environment
-elseif(HIP_FOUND)
-    message(STATUS "Found ROCm: " ${HIP_VERSION})
-
-    # Convert cuda code to hip code inplace
-    execute_process(COMMAND hipify-perl -inplace -print-stats gpu_sm_copy.cu
-                     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/)
-
-    # Add HIP targets
-    set_source_files_properties(gpu_sm_copy.cu PROPERTIES HIP_SOURCE_PROPERTY_FORMAT 1)
-    # Link with HIP
-    hip_add_executable(gpu_sm_copy gpu_sm_copy.cu)
-    # Install tergets
-    install(TARGETS gpu_sm_copy RUNTIME DESTINATION bin)
-
 else()
-    message(FATAL_ERROR "No CUDA or ROCm environment found.")
+    # ROCm environment
+    include(../rocm_common.cmake)
+    find_package(HIP QUIET)
+    if(HIP_FOUND)
+        message(STATUS "Found ROCm: " ${HIP_VERSION})
+
+        # Convert cuda code to hip code inplace
+        execute_process(COMMAND hipify-perl -inplace -print-stats gpu_sm_copy.cu
+                        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/)
+
+        # Add HIP targets
+        set_source_files_properties(gpu_sm_copy.cu PROPERTIES HIP_SOURCE_PROPERTY_FORMAT 1)
+        # Link with HIP
+        hip_add_executable(gpu_sm_copy gpu_sm_copy.cu)
+        # Install tergets
+        install(TARGETS gpu_sm_copy RUNTIME DESTINATION bin)
+    else()
+        message(FATAL_ERROR "No CUDA or ROCm environment found.")
+    endif()
 endif()

--- a/superbench/benchmarks/micro_benchmarks/gpu_sm_copy_performance/CMakeLists.txt
+++ b/superbench/benchmarks/micro_benchmarks/gpu_sm_copy_performance/CMakeLists.txt
@@ -13,7 +13,6 @@ find_package(HIP QUIET)
 # Cuda environment
 if(CUDAToolkit_FOUND)
     message(STATUS "Found CUDA: " ${CUDAToolkit_VERSION})
-    enable_language(CUDA)
 
     add_executable(gpu_sm_copy gpu_sm_copy.cu)
     set_property(TARGET gpu_sm_copy PROPERTY CUDA_ARCHITECTURES ${NVCC_ARCHS_SUPPORTED})
@@ -22,7 +21,7 @@ if(CUDAToolkit_FOUND)
 # ROCm environment
 elseif(HIP_FOUND)
     message(STATUS "Found ROCm: " ${HIP_VERSION})
-    
+
     # Convert cuda code to hip code inplace
     execute_process(COMMAND hipify-perl -inplace -print-stats gpu_sm_copy.cu
                      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/)
@@ -37,4 +36,3 @@ elseif(HIP_FOUND)
 else()
     message(FATAL_ERROR "No CUDA or ROCm environment found.")
 endif()
-

--- a/superbench/benchmarks/micro_benchmarks/kernel_launch_overhead/CMakeLists.txt
+++ b/superbench/benchmarks/micro_benchmarks/kernel_launch_overhead/CMakeLists.txt
@@ -13,7 +13,6 @@ find_package(HIP QUIET)
 # Cuda environment
 if(CUDAToolkit_FOUND)
     message(STATUS "Found CUDA: " ${CUDAToolkit_VERSION})
-    enable_language(CUDA)
 
     add_executable(kernel_launch_overhead kernel_launch.cu)
     set_property(TARGET kernel_launch_overhead PROPERTY CUDA_ARCHITECTURES ${NVCC_ARCHS_SUPPORTED})
@@ -22,7 +21,7 @@ if(CUDAToolkit_FOUND)
 # ROCm environment
 elseif(HIP_FOUND)
     message(STATUS "Found HIP: " ${HIP_VERSION})
-    
+
     # Convert cuda code to hip code inplace
     execute_process(COMMAND hipify-perl -inplace -print-stats kernel_launch.cu
                      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/)
@@ -37,4 +36,3 @@ elseif(HIP_FOUND)
 else()
     message(FATAL_ERROR "No CUDA or ROCm environment found.")
 endif()
-

--- a/superbench/benchmarks/micro_benchmarks/kernel_launch_overhead/CMakeLists.txt
+++ b/superbench/benchmarks/micro_benchmarks/kernel_launch_overhead/CMakeLists.txt
@@ -5,34 +5,34 @@ cmake_minimum_required(VERSION 3.18)
 
 project(kernel_launch_overhead LANGUAGES CXX)
 
-include(../cuda_common.cmake)
 find_package(CUDAToolkit QUIET)
-include(../rocm_common.cmake)
-find_package(HIP QUIET)
 
 # Cuda environment
 if(CUDAToolkit_FOUND)
     message(STATUS "Found CUDA: " ${CUDAToolkit_VERSION})
 
+    include(../cuda_common.cmake)
     add_executable(kernel_launch_overhead kernel_launch.cu)
     set_property(TARGET kernel_launch_overhead PROPERTY CUDA_ARCHITECTURES ${NVCC_ARCHS_SUPPORTED})
     install(TARGETS kernel_launch_overhead RUNTIME DESTINATION bin)
-
-# ROCm environment
-elseif(HIP_FOUND)
-    message(STATUS "Found HIP: " ${HIP_VERSION})
-
-    # Convert cuda code to hip code inplace
-    execute_process(COMMAND hipify-perl -inplace -print-stats kernel_launch.cu
-                     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/)
-
-    # Add HIP targets
-    set_source_files_properties(kernel_launch.cu PROPERTIES HIP_SOURCE_PROPERTY_FORMAT 1)
-    # Link with HIP
-    hip_add_executable(kernel_launch_overhead kernel_launch.cu)
-    # Install tergets
-    install(TARGETS kernel_launch_overhead RUNTIME DESTINATION bin)
-
 else()
-    message(FATAL_ERROR "No CUDA or ROCm environment found.")
+    # ROCm environment
+    include(../rocm_common.cmake)
+    find_package(HIP QUIET)
+    if(HIP_FOUND)
+        message(STATUS "Found HIP: " ${HIP_VERSION})
+
+        # Convert cuda code to hip code inplace
+        execute_process(COMMAND hipify-perl -inplace -print-stats kernel_launch.cu
+                        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/)
+
+        # Add HIP targets
+        set_source_files_properties(kernel_launch.cu PROPERTIES HIP_SOURCE_PROPERTY_FORMAT 1)
+        # Link with HIP
+        hip_add_executable(kernel_launch_overhead kernel_launch.cu)
+        # Install tergets
+        install(TARGETS kernel_launch_overhead RUNTIME DESTINATION bin)
+    else()
+        message(FATAL_ERROR "No CUDA or ROCm environment found.")
+    endif()
 endif()


### PR DESCRIPTION
**Description**
1. Do `enable_language(CUDA)` before using `CMAKE_CUDA_COMPILER_VERSION`
2. use `cmake --install` to install target which will call `cmake -P cmake_install.cmake` instead of `make Makefile` to avoid issue `make: *** No rule to make target 'install'.  Stop.`

