### PR TITLE
Bug: Fix Bug - Add barrier before 'destroy_process_group' in model benchmarks

### DIFF
--- a/superbench/benchmarks/model_benchmarks/pytorch_base.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_base.py
@@ -174,6 +174,7 @@ class PytorchBase(ModelBenchmark):
 
         try:
             if self._args.distributed_impl == DistributedImpl.DDP:
+                torch.distributed.barrier()
                 torch.distributed.destroy_process_group()
         except BaseException as e:
             self._result.set_return_code(ReturnCode.DISTRIBUTED_SETTING_DESTROY_FAILURE)

--- a/superbench/runner/runner.py
+++ b/superbench/runner/runner.py
@@ -128,7 +128,7 @@ class SuperBenchRunner():
                 '--use_env --no_python --nproc_per_node={proc_num} '
                 '--nnodes={node_num} --node_rank=$NODE_RANK '
                 '--master_addr=$MASTER_ADDR --master_port=$MASTER_PORT '
-                '{command} {torch_distributed_suffix} {model_name}'
+                '{command} {torch_distributed_suffix}'
             ).format(
                 proc_num=mode.proc_num,
                 node_num=1 if mode.node_num == 1 else '$NNODES',
@@ -137,8 +137,6 @@ class SuperBenchRunner():
                     'superbench.benchmarks.{name}.parameters.distributed_impl=ddp '
                     'superbench.benchmarks.{name}.parameters.distributed_backend=nccl'
                 ).format(name=benchmark_name),
-                model_name=('superbench.benchmarks.{name}.models=[{model}]'
-                            ).format(name=benchmark_name, model=mode.model_name)
             )
         elif mode.name == 'mpi':
             mode_command = (
@@ -343,10 +341,7 @@ class SuperBenchRunner():
                             'proc_rank': proc_rank
                         }) for proc_rank in range(mode.proc_num)
                     )
-                elif mode.name == 'torch.distributed':
-                    for m in self._sb_benchmarks[benchmark_name].models:
-                        self._run_proc(benchmark_name, mode, {'proc_rank': 0, 'model_name': m})
-                elif mode.name == 'mpi':
+                elif mode.name == 'torch.distributed' or mode.name == 'mpi':
                     self._run_proc(benchmark_name, mode, {'proc_rank': 0})
                 else:
                     logger.warning('Unknown mode %s.', mode.name)


### PR DESCRIPTION
**Description**
Add barrier before 'destroy_process_group' to resolve the bug due to when multi models in one model benchmark, some processes haven't finished the previous process group while others failed to initialize new process group for the next model on rocm4.x when running bert_models.

**Major Revision**
-  Add barrier before 'destroy_process_group'.
