### PR TITLE
Benchmarks: Build Pipeline - Update rccl-test git submodule to dc1ad48

### DIFF
--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -65,7 +65,7 @@ ifneq (,$(wildcard fio/Makefile))
 	cd ./fio && ./configure --prefix=$(SB_MICRO_PATH) && make -j && make install
 endif
 
-# Build rccl-tests from commit cc34c5 of develop branch (default branch).
+# Build rccl-tests from commit dc1ad48 of develop branch (default branch).
 rocm_rccl_tests: sb_micro_path
 ifneq (, $(wildcard rccl-tests/Makefile))
 	cd ./rccl-tests && make MPI=1 MPI_HOME=$(MPI_HOME) HIP_HOME=$(HIP_HOME) RCCL_HOME=$(RCCL_HOME) -j


### PR DESCRIPTION
**Description**
Update rccl-test git submodule to dc1ad48 which fix the bug of division by zero

**Major Revision**
- update rccl-test git submodule to dc1ad48

