### PR TITLE
CI/CD - Disable version update, allow security update only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
     allow:
       - dependency-type: "direct"
     labels:
@@ -16,6 +17,7 @@ updates:
     directory: "/website/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
     assignees:


### PR DESCRIPTION
Disable dependabot version update, allow security update only.
Reference:
https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#open-pull-requests-limit.