### PR TITLE
Benchmark: Replace `-c` argument with `-N` for `numactl` in Configuration

### DIFF
--- a/superbench/config/azure_ndv4.yaml
+++ b/superbench/config/azure_ndv4.yaml
@@ -59,7 +59,7 @@ superbench:
       modes:
         - name: local
           proc_num: 8
-          prefix: CUDA_VISIBLE_DEVICES={proc_rank} numactl -c $(({proc_rank}/2))
+          prefix: CUDA_VISIBLE_DEVICES={proc_rank} numactl -N $(({proc_rank}/2))
           parallel: yes
     disk-benchmark:
       enable: false

--- a/superbench/config/default.yaml
+++ b/superbench/config/default.yaml
@@ -61,7 +61,7 @@ superbench:
       modes:
         - name: local
           proc_num: 8
-          prefix: CUDA_VISIBLE_DEVICES={proc_rank} numactl -c $(({proc_rank}/2))
+          prefix: CUDA_VISIBLE_DEVICES={proc_rank} numactl -N $(({proc_rank}/2))
           parallel: yes
     gpu-copy-bw:
       enable: true

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -66,10 +66,10 @@ class RunnerTestCase(unittest.TestCase):
                     'name': 'local',
                     'proc_num': 8,
                     'proc_rank': 6,
-                    'prefix': 'CUDA_VISIBLE_DEVICES={proc_rank} numactl -c $(({proc_rank}/2))'
+                    'prefix': 'CUDA_VISIBLE_DEVICES={proc_rank} numactl -N $(({proc_rank}/2))'
                 },
                 'expected_command': (
-                    'PROC_RANK=6 CUDA_VISIBLE_DEVICES=6 numactl -c $((6/2)) '
+                    'PROC_RANK=6 CUDA_VISIBLE_DEVICES=6 numactl -N $((6/2)) '
                     f'sb exec --output-dir {self.sb_output_dir} -c sb.config.yaml -C superbench.enable=foo'
                 ),
             },


### PR DESCRIPTION
**Description**
Replace `-c` argument with `-N` for `numactl` since the old `-c`/`--cpubind` argument is deprecated.