### PR TITLE
Docs - Add a small note for using release container version

### DIFF
--- a/docs/getting-started/run-superbench.md
+++ b/docs/getting-started/run-superbench.md
@@ -28,6 +28,9 @@ sb deploy -f remote.ini --host-password [password]
 You should deploy corresponding Docker image to use release version, for example,
 
 `sb deploy -f local.ini -i superbench/superbench:v0.3.0-cuda11.1.1`
+
+You should note that version of git repo only determines version of sb CLI, and not the sb container. You should define the container version even if you specified a release version for the git clone.
+
 :::
 
 ## Run


### PR DESCRIPTION
**Description**
Minor doc change to highlight sb CLI version is independent of the sb container version.