### PR TITLE
Bug - Fix issues for Ansible and benchmarks

### DIFF
--- a/superbench/runner/playbooks/fetch_results.yaml
+++ b/superbench/runner/playbooks/fetch_results.yaml
@@ -1,11 +1,13 @@
 - name: Fetch Results
   hosts: all
   gather_facts: true
+  vars:
+    workspace: '{{ ansible_user_dir }}/sb-workspace'
   tasks:
     - name: Synchronize Output Directory
       ansible.posix.synchronize:
         mode: pull
-        src: '{{ sb_output_dir }}/'
+        src: '{{ sb_output_dir if sb_output_dir.startswith("/") else workspace + "/" + sb_output_dir  }}/'
         dest: '{{ absolute_output_dir }}/nodes/{{ ansible_hostname }}'
         rsync_opts:
           - --exclude=nodes

--- a/superbench/runner/runner.py
+++ b/superbench/runner/runner.py
@@ -39,7 +39,7 @@ class SuperBenchRunner():
         self._ansible_client = AnsibleClient(ansible_config)
 
         self.__set_logger('sb-run.log')
-        logger.info('Runner uses config: %s.', pformat(self._sb_config))
+        logger.info('Runner uses config: %s.', pformat(OmegaConf.to_container(self._sb_config, resolve=True)))
         logger.info('Runner writes to: %s.', str(self._output_path))
 
         self._sb_benchmarks = self._sb_config.superbench.benchmarks

--- a/tests/ansible/tests/test_deploy.yaml
+++ b/tests/ansible/tests/test_deploy.yaml
@@ -14,4 +14,4 @@
   vars:
     ssh_port: 12345
     output_dir: /tmp/test_ansible
-    docker_image: superbench/superbench
+    docker_image: superbench/superbench:v0.3.0-cuda11.1.1

--- a/tests/ansible/tests/test_deploy.yaml
+++ b/tests/ansible/tests/test_deploy.yaml
@@ -14,4 +14,5 @@
   vars:
     ssh_port: 12345
     output_dir: /tmp/test_ansible
+    # use a mock superbench image (requires `sb` binary inside)
     docker_image: superbench/superbench:v0.3.0-cuda11.1.1

--- a/tests/runner/test_ansible.py
+++ b/tests/runner/test_ansible.py
@@ -47,7 +47,6 @@ class AnsibleClientTestCase(unittest.TestCase):
         """Test initial config of client."""
         self.assertDictEqual(
             self.ansible_client._config, {
-                'private_data_dir': None,
                 'host_pattern': 'all',
                 'cmdline': f'--forks 5 --inventory {self.host_file} --user user --ask-pass --ask-become-pass',
                 'passwords': {
@@ -71,7 +70,6 @@ class AnsibleClientTestCase(unittest.TestCase):
         cmd = 'ls -la'
         self.assertDictEqual(
             self.ansible_client.get_shell_config(cmd), {
-                'private_data_dir': None,
                 'host_pattern': 'all',
                 'cmdline': f'--forks 5 --inventory {self.host_file} --user user --ask-pass --ask-become-pass',
                 'passwords': {
@@ -87,7 +85,6 @@ class AnsibleClientTestCase(unittest.TestCase):
         """Test get_playbook_config of client."""
         self.assertDictEqual(
             self.ansible_client.get_playbook_config('play', {'foo': 'bar'}), {
-                'private_data_dir': None,
                 'host_pattern': 'all',
                 'cmdline': f'--forks 5 --inventory {self.host_file} --user user --ask-pass --ask-become-pass',
                 'passwords': {


### PR DESCRIPTION
__Description__

Fix issues for Ansible and benchmarks:
* Cleanup Ansible runner private data dir to avoid out of disk space issue when node number is large.
* Support both absolute and relative paths when fecth results.
* Use a deterministic image in Ansible test to avoid image update.
* Update logging format.
* Delete torch models and inputs after export.