### PR TITLE
[hack] running `sb exec` commands locally (no docker)

### DIFF
--- a/superbench/cli/_handler.py
+++ b/superbench/cli/_handler.py
@@ -294,5 +294,5 @@ def run_command_handler(
         config_override=config_override,
     )
 
-    runner = SuperBenchRunner(sb_config, docker_config, ansible_config, sb_output_dir)
+    runner = SuperBenchRunner(sb_config, docker_config, ansible_config, sb_output_dir, config_file)
     runner.run()

--- a/superbench/runner/playbooks/check_env.yaml
+++ b/superbench/runner/playbooks/check_env.yaml
@@ -14,6 +14,12 @@
       # config env
       {{ env | default('') }}
   tasks:
+    - name: Updating Config
+      copy:
+        src: '{{ output_dir }}/sb.config.yaml'
+        dest: '{{ workspace }}/sb.config.yaml'
+        mode: 0644
+      become: yes
     - name: Updating Env Variables
       copy:
         content: '{{ sb_env }}'

--- a/superbench/runner/playbooks/check_env.yaml
+++ b/superbench/runner/playbooks/check_env.yaml
@@ -1,19 +1,3 @@
-- name: Runtime Environment Check
-  hosts: all
-  gather_facts: false
-  max_fail_percentage: 0
-  vars:
-    container: sb-workspace
-  tasks:
-    - name: Checking container status
-      shell: docker inspect --format={{ '{{.State.Running}}' }} {{ container }}
-      register: result
-      ignore_errors: true
-      become: yes
-    - fail:
-        msg: Container {{ container }} is not running.
-      when: result is failed or result.stdout != "true"
-
 - name: Runtime Environment Update
   hosts: all
   gather_facts: true

--- a/superbench/runner/playbooks/check_env.yaml
+++ b/superbench/runner/playbooks/check_env.yaml
@@ -2,8 +2,7 @@
   hosts: all
   gather_facts: true
   vars:
-    workspace: '{{ ansible_user_dir }}/sb-workspace'
-    container: sb-workspace
+    workspace: '/superbench'
     sb_nodes: '{{ hostvars.values() | map(attribute="ansible_hostname") | sort }}'
     sb_env: |
       # pytorch env
@@ -15,12 +14,6 @@
       # config env
       {{ env | default('') }}
   tasks:
-    - name: Updating Config
-      copy:
-        src: '{{ output_dir }}/sb.config.yaml'
-        dest: '{{ workspace }}/sb.config.yaml'
-        mode: 0644
-      become: yes
     - name: Updating Env Variables
       copy:
         content: '{{ sb_env }}'

--- a/superbench/runner/playbooks/fetch_results.yaml
+++ b/superbench/runner/playbooks/fetch_results.yaml
@@ -2,7 +2,7 @@
   hosts: all
   gather_facts: true
   vars:
-    workspace: '{{ ansible_user_dir }}/sb-workspace'
+    workspace: '/superbench'
   tasks:
     - name: Synchronize Output Directory
       ansible.posix.synchronize:

--- a/superbench/runner/runner.py
+++ b/superbench/runner/runner.py
@@ -359,7 +359,7 @@ class SuperBenchRunner():
         logger.info('Runner is going to run %s in %s mode, proc rank %d.', benchmark_name, mode.name, mode.proc_rank)
         ansible_runner_config = self._ansible_client.get_shell_config(
             (
-                "set -o allexport && source /superbench/sb.env && set +o allexport && {command}"
+                "set -o allexport && source sb.env && set +o allexport && {command}"
             ).format(command=self.__get_mode_command(benchmark_name, mode))
         )
         if mode.name == 'mpi':

--- a/superbench/runner/runner.py
+++ b/superbench/runner/runner.py
@@ -113,7 +113,7 @@ class SuperBenchRunner():
         Return:
             str: Runner command.
         """
-        exec_command = ('sb exec --output-dir {output_dir} -c {config} -C superbench.enable={name}').format(
+        exec_command = ('sb exec --output-dir {output_dir} -c /superbench/sb.config.yaml -C superbench.enable={name}').format(
             name=benchmark_name,
             config=self._sb_config_file,
             output_dir=self._sb_output_dir,

--- a/superbench/runner/runner.py
+++ b/superbench/runner/runner.py
@@ -39,7 +39,7 @@ class SuperBenchRunner():
         self._ansible_client = AnsibleClient(ansible_config)
         self._sb_config_file = sb_config_file or "sb.config.yaml"
 
-        self.__set_logger(f'{self._output_path}/sb-run.log')
+        self.__set_logger(f'sb-run.log')
         logger.info('Runner uses config: %s.', pformat(OmegaConf.to_container(self._sb_config, resolve=True)))
         logger.info('Runner writes to: %s.', str(self._output_path))
 

--- a/superbench/runner/runner.py
+++ b/superbench/runner/runner.py
@@ -174,50 +174,53 @@ class SuperBenchRunner():
         self._ansible_client.run(self._ansible_client.get_playbook_config('deploy.yaml', extravars=extravars))
 
     def check_env(self):    # pragma: no cover
-        """Check SuperBench environment."""
-        logger.info('Checking SuperBench environment.')
-        OmegaConf.save(config=self._sb_config, f=str(self._output_path / 'sb.config.yaml'))
-        self._ansible_client.run(
-            self._ansible_client.get_playbook_config(
-                'check_env.yaml',
-                extravars={
-                    'output_dir': str(self._output_path),
-                    'env': '\n'.join(f'{k}={v}' for k, v in self._sb_config.superbench.env.items()),
-                }
-            )
-        )
+        pass
+        # """Check SuperBench environment."""
+        # logger.info('Checking SuperBench environment.')
+        # OmegaConf.save(config=self._sb_config, f=str(self._output_path / 'sb.config.yaml'))
+        # self._ansible_client.run(
+        #     self._ansible_client.get_playbook_config(
+        #         'check_env.yaml',
+        #         extravars={
+        #             'output_dir': str(self._output_path),
+        #             'env': '\n'.join(f'{k}={v}' for k, v in self._sb_config.superbench.env.items()),
+        #         }
+        #     )
+        # )
 
     def fetch_results(self):    # pragma: no cover
-        """Fetch benchmark results on all nodes."""
-        try:
-            (self._output_path / 'nodes').mkdir(mode=0o755, parents=True, exist_ok=True)
-        except Exception:
-            logger.exception('Failed to create directory %s.', str(self._output_path / 'nodes'))
-            raise
-        self._ansible_client.run(
-            self._ansible_client.get_playbook_config(
-                'fetch_results.yaml',
-                extravars={
-                    'sb_output_dir': self._sb_output_dir,
-                    'absolute_output_dir': str(self._output_path),
-                }
-            )
-        )
+        pass
+        # """Fetch benchmark results on all nodes."""
+        # try:
+        #     (self._output_path / 'nodes').mkdir(mode=0o755, parents=True, exist_ok=True)
+        # except Exception:
+        #     logger.exception('Failed to create directory %s.', str(self._output_path / 'nodes'))
+        #     raise
+        # self._ansible_client.run(
+        #     self._ansible_client.get_playbook_config(
+        #         'fetch_results.yaml',
+        #         extravars={
+        #             'sb_output_dir': self._sb_output_dir,
+        #             'absolute_output_dir': str(self._output_path),
+        #         }
+        #     )
+        # )
 
     def __create_results_summary(self):    # pragma: no cover
-        """Create the result summary file of all nodes."""
-        all_results = list()
-        for node_path in (self._output_path / 'nodes').glob('*'):
-            if not node_path.is_dir():
-                continue
-            results_summary = self.__create_single_node_summary(node_path)
-            results_summary['node'] = node_path.name
-            all_results.append(results_summary)
-
-        with (self._output_path / 'results-summary.jsonl').open(mode='w') as f:
-            for result in all_results:
-                json.dump(result, f)
-                f.write('\n')
+        pass
+        # """Create the result summary file of all nodes."""
+        # all_results = list()
+        # for node_path in (self._output_path / 'nodes').glob('*'):
+        #     if not node_path.is_dir():
+        #         continue
+        #     results_summary = self.__create_single_node_summary(node_path)
+        #     results_summary['node'] = node_path.name
+        #     all_results.append(results_summary)
+        #
+        # with (self._output_path / 'results-summary.jsonl').open(mode='w') as f:
+        #     for result in all_results:
+        #         json.dump(result, f)
+        #         f.write('\n')
 
     def __create_single_node_summary(self, node_path):    # pragma: no cover # noqa: C901
         """Create the result summary file of single node.
@@ -278,6 +281,7 @@ class SuperBenchRunner():
             dict: Flattened result with metric as key.
         """
         metrics_summary = dict()
+        return metrics_summary
         for benchmark_name in results_summary:
             for metric in results_summary[benchmark_name]:
                 metric_name = '{}/{}'.format(benchmark_name, metric)

--- a/superbench/runner/runner.py
+++ b/superbench/runner/runner.py
@@ -384,4 +384,3 @@ class SuperBenchRunner():
                     self._run_proc(benchmark_name, mode, {'proc_rank': 0})
                 else:
                     logger.warning('Unknown mode %s.', mode.name)
-        self.__create_results_summary()

--- a/superbench/runner/runner.py
+++ b/superbench/runner/runner.py
@@ -39,7 +39,7 @@ class SuperBenchRunner():
         self._ansible_client = AnsibleClient(ansible_config)
         self._sb_config_file = sb_config_file or "sb.config.yaml"
 
-        self.__set_logger(f'sb-run.log')
+        self.__set_logger('sb-run.log')
         logger.info('Runner uses config: %s.', pformat(OmegaConf.to_container(self._sb_config, resolve=True)))
         logger.info('Runner writes to: %s.', str(self._output_path))
 
@@ -174,53 +174,50 @@ class SuperBenchRunner():
         self._ansible_client.run(self._ansible_client.get_playbook_config('deploy.yaml', extravars=extravars))
 
     def check_env(self):    # pragma: no cover
-        pass
-        # """Check SuperBench environment."""
-        # logger.info('Checking SuperBench environment.')
-        # OmegaConf.save(config=self._sb_config, f=str(self._output_path / 'sb.config.yaml'))
-        # self._ansible_client.run(
-        #     self._ansible_client.get_playbook_config(
-        #         'check_env.yaml',
-        #         extravars={
-        #             'output_dir': str(self._output_path),
-        #             'env': '\n'.join(f'{k}={v}' for k, v in self._sb_config.superbench.env.items()),
-        #         }
-        #     )
-        # )
+        """Check SuperBench environment."""
+        logger.info('Checking SuperBench environment.')
+        OmegaConf.save(config=self._sb_config, f=str(self._output_path / 'sb.config.yaml'))
+        self._ansible_client.run(
+            self._ansible_client.get_playbook_config(
+                'check_env.yaml',
+                extravars={
+                    'output_dir': str(self._output_path),
+                    'env': '\n'.join(f'{k}={v}' for k, v in self._sb_config.superbench.env.items()),
+                }
+            )
+        )
 
     def fetch_results(self):    # pragma: no cover
-        pass
-        # """Fetch benchmark results on all nodes."""
-        # try:
-        #     (self._output_path / 'nodes').mkdir(mode=0o755, parents=True, exist_ok=True)
-        # except Exception:
-        #     logger.exception('Failed to create directory %s.', str(self._output_path / 'nodes'))
-        #     raise
-        # self._ansible_client.run(
-        #     self._ansible_client.get_playbook_config(
-        #         'fetch_results.yaml',
-        #         extravars={
-        #             'sb_output_dir': self._sb_output_dir,
-        #             'absolute_output_dir': str(self._output_path),
-        #         }
-        #     )
-        # )
+        """Fetch benchmark results on all nodes."""
+        try:
+            (self._output_path / 'nodes').mkdir(mode=0o755, parents=True, exist_ok=True)
+        except Exception:
+            logger.exception('Failed to create directory %s.', str(self._output_path / 'nodes'))
+            raise
+        self._ansible_client.run(
+            self._ansible_client.get_playbook_config(
+                'fetch_results.yaml',
+                extravars={
+                    'sb_output_dir': self._sb_output_dir,
+                    'absolute_output_dir': str(self._output_path),
+                }
+            )
+        )
 
     def __create_results_summary(self):    # pragma: no cover
-        pass
-        # """Create the result summary file of all nodes."""
-        # all_results = list()
-        # for node_path in (self._output_path / 'nodes').glob('*'):
-        #     if not node_path.is_dir():
-        #         continue
-        #     results_summary = self.__create_single_node_summary(node_path)
-        #     results_summary['node'] = node_path.name
-        #     all_results.append(results_summary)
-        #
-        # with (self._output_path / 'results-summary.jsonl').open(mode='w') as f:
-        #     for result in all_results:
-        #         json.dump(result, f)
-        #         f.write('\n')
+        """Create the result summary file of all nodes."""
+        all_results = list()
+        for node_path in (self._output_path / 'nodes').glob('*'):
+            if not node_path.is_dir():
+                continue
+            results_summary = self.__create_single_node_summary(node_path)
+            results_summary['node'] = node_path.name
+            all_results.append(results_summary)
+
+        with (self._output_path / 'results-summary.jsonl').open(mode='w') as f:
+            for result in all_results:
+                json.dump(result, f)
+                f.write('\n')
 
     def __create_single_node_summary(self, node_path):    # pragma: no cover # noqa: C901
         """Create the result summary file of single node.
@@ -281,7 +278,6 @@ class SuperBenchRunner():
             dict: Flattened result with metric as key.
         """
         metrics_summary = dict()
-        return metrics_summary
         for benchmark_name in results_summary:
             for metric in results_summary[benchmark_name]:
                 metric_name = '{}/{}'.format(benchmark_name, metric)
@@ -373,6 +369,7 @@ class SuperBenchRunner():
 
     def run(self):
         """Run the SuperBench benchmarks distributedly."""
+        self.check_env()
         for benchmark_name in self._sb_benchmarks:
             if benchmark_name not in self._sb_enabled_benchmarks:
                 continue
@@ -388,3 +385,4 @@ class SuperBenchRunner():
                     self._run_proc(benchmark_name, mode, {'proc_rank': 0})
                 else:
                     logger.warning('Unknown mode %s.', mode.name)
+        self.__create_results_summary()

--- a/superbench/runner/runner.py
+++ b/superbench/runner/runner.py
@@ -362,9 +362,7 @@ class SuperBenchRunner():
         mode.update(vars)
         logger.info('Runner is going to run %s in %s mode, proc rank %d.', benchmark_name, mode.name, mode.proc_rank)
         ansible_runner_config = self._ansible_client.get_shell_config(
-            (
-                "'set -o allexport && source /superbench/sb.env && set +o allexport && {command}'"
-            ).format(command=self.__get_mode_command(benchmark_name, mode))
+            self.__get_mode_command(benchmark_name, mode)
         )
         if mode.name == 'mpi':
             ansible_runner_config = self._ansible_client.update_mpi_config(ansible_runner_config)

--- a/superbench/runner/runner.py
+++ b/superbench/runner/runner.py
@@ -369,7 +369,6 @@ class SuperBenchRunner():
 
     def run(self):
         """Run the SuperBench benchmarks distributedly."""
-        self.check_env()
         for benchmark_name in self._sb_benchmarks:
             if benchmark_name not in self._sb_enabled_benchmarks:
                 continue
@@ -385,5 +384,4 @@ class SuperBenchRunner():
                     self._run_proc(benchmark_name, mode, {'proc_rank': 0})
                 else:
                     logger.warning('Unknown mode %s.', mode.name)
-
         self.__create_results_summary()

--- a/superbench/runner/runner.py
+++ b/superbench/runner/runner.py
@@ -359,7 +359,7 @@ class SuperBenchRunner():
         logger.info('Runner is going to run %s in %s mode, proc rank %d.', benchmark_name, mode.name, mode.proc_rank)
         ansible_runner_config = self._ansible_client.get_shell_config(
             (
-                "set -o allexport && source /superbench/sb.env && set +o allexport && {command}"
+                "/bin/bash -c 'set -o allexport && source /superbench/sb.env && set +o allexport && {command}'"
             ).format(command=self.__get_mode_command(benchmark_name, mode))
         )
         if mode.name == 'mpi':

--- a/superbench/runner/runner.py
+++ b/superbench/runner/runner.py
@@ -362,7 +362,9 @@ class SuperBenchRunner():
         mode.update(vars)
         logger.info('Runner is going to run %s in %s mode, proc rank %d.', benchmark_name, mode.name, mode.proc_rank)
         ansible_runner_config = self._ansible_client.get_shell_config(
-            self.__get_mode_command(benchmark_name, mode)
+            (
+                "set -o allexport && source /superbench/sb.env && set +o allexport && {command}"
+            ).format(command=self.__get_mode_command(benchmark_name, mode))
         )
         if mode.name == 'mpi':
             ansible_runner_config = self._ansible_client.update_mpi_config(ansible_runner_config)

--- a/superbench/runner/runner.py
+++ b/superbench/runner/runner.py
@@ -22,7 +22,7 @@ from superbench.monitor import MonitorRecord
 
 class SuperBenchRunner():
     """SuperBench runner class."""
-    def __init__(self, sb_config, docker_config, ansible_config, sb_output_dir):
+    def __init__(self, sb_config, docker_config, ansible_config, sb_output_dir, sb_config_file=None):
         """Initilize.
 
         Args:
@@ -37,6 +37,7 @@ class SuperBenchRunner():
         self._sb_output_dir = sb_output_dir
         self._output_path = Path(sb_output_dir).expanduser().resolve()
         self._ansible_client = AnsibleClient(ansible_config)
+        self._sb_config_file = sb_config_file or "sb.config.yaml"
 
         self.__set_logger('sb-run.log')
         logger.info('Runner uses config: %s.', pformat(OmegaConf.to_container(self._sb_config, resolve=True)))
@@ -112,8 +113,9 @@ class SuperBenchRunner():
         Return:
             str: Runner command.
         """
-        exec_command = ('sb exec --output-dir {output_dir} -c sb.config.yaml -C superbench.enable={name}').format(
+        exec_command = ('sb exec --output-dir {output_dir} -c {config} -C superbench.enable={name}').format(
             name=benchmark_name,
+            config=self._sb_config_file,
             output_dir=self._sb_output_dir,
         )
         mode_command = exec_command

--- a/superbench/runner/runner.py
+++ b/superbench/runner/runner.py
@@ -359,13 +359,12 @@ class SuperBenchRunner():
         logger.info('Runner is going to run %s in %s mode, proc rank %d.', benchmark_name, mode.name, mode.proc_rank)
         ansible_runner_config = self._ansible_client.get_shell_config(
             (
-                'docker exec sb-workspace bash -c '
                 "'set -o allexport && source sb.env && set +o allexport && {command}'"
             ).format(command=self.__get_mode_command(benchmark_name, mode))
         )
         if mode.name == 'mpi':
             ansible_runner_config = self._ansible_client.update_mpi_config(ansible_runner_config)
-        rc = self._ansible_client.run(ansible_runner_config, sudo=True)
+        rc = self._ansible_client.run(ansible_runner_config)
         return rc
 
     def run(self):

--- a/superbench/runner/runner.py
+++ b/superbench/runner/runner.py
@@ -386,6 +386,5 @@ class SuperBenchRunner():
                     self._run_proc(benchmark_name, mode, {'proc_rank': 0})
                 else:
                     logger.warning('Unknown mode %s.', mode.name)
-            self.fetch_results()
 
         self.__create_results_summary()

--- a/superbench/runner/runner.py
+++ b/superbench/runner/runner.py
@@ -39,7 +39,7 @@ class SuperBenchRunner():
         self._ansible_client = AnsibleClient(ansible_config)
         self._sb_config_file = sb_config_file or "sb.config.yaml"
 
-        self.__set_logger('sb-run.log')
+        self.__set_logger(f'{self._output_path}/sb-run.log')
         logger.info('Runner uses config: %s.', pformat(OmegaConf.to_container(self._sb_config, resolve=True)))
         logger.info('Runner writes to: %s.', str(self._output_path))
 
@@ -359,7 +359,7 @@ class SuperBenchRunner():
         logger.info('Runner is going to run %s in %s mode, proc rank %d.', benchmark_name, mode.name, mode.proc_rank)
         ansible_runner_config = self._ansible_client.get_shell_config(
             (
-                "'set -o allexport && source sb.env && set +o allexport && {command}'"
+                "'set -o allexport && source /superbench/sb.env && set +o allexport && {command}'"
             ).format(command=self.__get_mode_command(benchmark_name, mode))
         )
         if mode.name == 'mpi':

--- a/superbench/runner/runner.py
+++ b/superbench/runner/runner.py
@@ -359,7 +359,7 @@ class SuperBenchRunner():
         logger.info('Runner is going to run %s in %s mode, proc rank %d.', benchmark_name, mode.name, mode.proc_rank)
         ansible_runner_config = self._ansible_client.get_shell_config(
             (
-                "set -o allexport && source sb.env && set +o allexport && {command}"
+                "set -o allexport && source /superbench/sb.env && set +o allexport && {command}"
             ).format(command=self.__get_mode_command(benchmark_name, mode))
         )
         if mode.name == 'mpi':


### PR DESCRIPTION
This PR removes docker from `sb exec` commands. This is needed when running `sb run` from inside a docker container.