### PR TITLE
Bug - fix HIP_ARCHITECTURES is empty issue in cmake>=3.21.0

### DIFF
--- a/superbench/benchmarks/micro_benchmarks/rocm_common.cmake
+++ b/superbench/benchmarks/micro_benchmarks/rocm_common.cmake
@@ -15,6 +15,12 @@ else()
     set(HIP_PATH $ENV{HIP_PATH})
 endif()
 
+# Turn off CMAKE_HIP_ARCHITECTURES Feature if cmake version is 3.21+
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.21.0)
+    set(CMAKE_HIP_ARCHITECTURES OFF)
+endif()
+message(STATUS "CMAKE HIP ARCHITECTURES: ${CMAKE_HIP_ARCHITECTURES}")
+
 if(EXISTS ${HIP_PATH})
     # Search for hip in common locations
     list(APPEND CMAKE_PREFIX_PATH ${HIP_PATH} ${ROCM_PATH})


### PR DESCRIPTION
**Description**
Fix HIP_ARCHITECTURES is empty issue with cmake>=3.21.0.
Refer to https://github.com/ROCm-Developer-Tools/HIP/pull/2364