### PR TITLE
Benchmarks - Keep BatchNorm as fp32 for pytorch cnn models cast to fp16

### DIFF
--- a/superbench/benchmarks/model_benchmarks/pytorch_cnn.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_cnn.py
@@ -14,6 +14,12 @@ from superbench.benchmarks.model_benchmarks.model_base import Optimizer
 from superbench.benchmarks.model_benchmarks.pytorch_base import PytorchBase
 from superbench.benchmarks.model_benchmarks.random_dataset import TorchRandomDataset
 
+def _keep_BatchNorm_as_float(module):
+    if isinstance(module, torch.nn.modules.batchnorm._BatchNorm):
+        module.float()
+    for child in module.children():
+        _keep_BatchNorm_as_float(child)
+    return module
 
 class PytorchCNN(PytorchBase):
     """The CNN benchmark class."""
@@ -63,6 +69,7 @@ class PytorchCNN(PytorchBase):
         try:
             self._model = getattr(models, self._args.model_type)()
             self._model = self._model.to(dtype=getattr(torch, precision.value))
+            self._model = _keep_BatchNorm_as_float(self._model)
             if self._gpu_available:
                 self._model = self._model.cuda()
         except BaseException as e:

--- a/superbench/benchmarks/model_benchmarks/pytorch_cnn.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_cnn.py
@@ -14,12 +14,14 @@ from superbench.benchmarks.model_benchmarks.model_base import Optimizer
 from superbench.benchmarks.model_benchmarks.pytorch_base import PytorchBase
 from superbench.benchmarks.model_benchmarks.random_dataset import TorchRandomDataset
 
+
 def _keep_BatchNorm_as_float(module):
     if isinstance(module, torch.nn.modules.batchnorm._BatchNorm):
         module.float()
     for child in module.children():
         _keep_BatchNorm_as_float(child)
     return module
+
 
 class PytorchCNN(PytorchBase):
     """The CNN benchmark class."""


### PR DESCRIPTION
**Description**
The BatchNorm operator is not numerically stable in fp16.  PyTorch documentation recommends to keep the BN op in fp32 for fp16 AMP models.  Refer to https://pytorch.org/docs/stable/amp.html#ops-that-can-autocast-to-float32.  Preserving BN in fp32 for superbench more accurately reflects real workloads.