### PR TITLE
Bug - Fix env path to absolute path

### DIFF
--- a/superbench/runner/playbooks/check_env.yaml
+++ b/superbench/runner/playbooks/check_env.yaml
@@ -40,8 +40,11 @@
     - name: Updating Env Variables
       copy:
         content: '{{ sb_env }}'
-        dest: '{{ workspace }}/sb.env'
+        dest: '{{ item }}'
         mode: 0644
+      with_items:
+        - '{{ workspace }}/sb.env'
+        - /tmp/sb.env
       become: yes
     - name: Updating Hostfile
       copy:

--- a/superbench/runner/runner.py
+++ b/superbench/runner/runner.py
@@ -387,7 +387,7 @@ class SuperBenchRunner():
         logger.info('Runner is going to run %s in %s mode, proc rank %d.', benchmark_name, mode.name, mode.proc_rank)
 
         timeout = self._sb_benchmarks[benchmark_name].timeout
-        env_list = '--env-file sb-workspace/sb.env'
+        env_list = '--env-file /tmp/sb.env'
         for k, v in mode.env.items():
             if isinstance(v, str):
                 env_list += f' -e {k}={str(v).format(proc_rank=mode.proc_rank, proc_num=mode.proc_num)}'


### PR DESCRIPTION
Fix env file path to absolute path in `docker exec`, in case there're mixed ssh and local connections or different users are used.