### PR TITLE
Bug: Benchmarks - remove fp16  samples type converting time for cnn and lstm models

### DIFF
--- a/superbench/benchmarks/model_benchmarks/pytorch_cnn.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_cnn.py
@@ -134,8 +134,8 @@ class PytorchCNN(PytorchBase):
             self._model.eval()
             while True:
                 for idx, sample in enumerate(self._dataloader):
-                    start = time.time()
                     sample = sample.to(dtype=getattr(torch, precision.value))
+                    start = time.time()
                     if self._gpu_available:
                         sample = sample.cuda()
                     self._model(sample)

--- a/superbench/benchmarks/model_benchmarks/pytorch_lstm.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_lstm.py
@@ -141,8 +141,8 @@ class PytorchLSTM(PytorchBase):
         curr_step = 0
         while True:
             for idx, sample in enumerate(self._dataloader):
-                start = time.time()
                 sample = sample.to(dtype=getattr(torch, precision.value))
+                start = time.time()
                 if self._gpu_available:
                     sample = sample.cuda()
                 self._optimizer.zero_grad()


### PR DESCRIPTION
**Description**
Remove fp16  samples type converting time for cnn and lstm models.

