### PR TITLE
Bug: Benchmarks - remove fp16 samples type converting time for training cnn and lstm inference

### DIFF
--- a/superbench/benchmarks/model_benchmarks/pytorch_cnn.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_cnn.py
@@ -101,8 +101,8 @@ class PytorchCNN(PytorchBase):
         curr_step = 0
         while True:
             for idx, sample in enumerate(self._dataloader):
-                start = time.time()
                 sample = sample.to(dtype=getattr(torch, precision.value))
+                start = time.time()
                 if self._gpu_available:
                     sample = sample.cuda()
                 self._optimizer.zero_grad()

--- a/superbench/benchmarks/model_benchmarks/pytorch_lstm.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_lstm.py
@@ -174,8 +174,8 @@ class PytorchLSTM(PytorchBase):
             self._model.eval()
             while True:
                 for idx, sample in enumerate(self._dataloader):
-                    start = time.time()
                     sample = sample.to(dtype=getattr(torch, precision.value))
+                    start = time.time()
                     if self._gpu_available:
                         sample = sample.cuda()
                     self._model(sample)


### PR DESCRIPTION
**Description**
remove fp16 samples type converting time for training cnn and lstm inference.
