### PR TITLE
Bug - Force to fix ort version as '1.10.0'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -173,7 +173,7 @@ setup(
         'nvidia': ['py3nvml>=0.2.6'],
         'ort': [
             'onnx>=1.10.2',
-            'onnxruntime-gpu>=1.9.0',
+            'onnxruntime-gpu==1.10.0',
         ],
         'torch': [
             'torch>=1.7.0a0',


### PR DESCRIPTION
**Description**
Force to fix ort version as '1.10.0' .

Bug in onnxruntime-gpu '1.11.0':

<img width="1491" alt="image" src="https://user-images.githubusercontent.com/37182275/163390954-d261682a-f81c-458c-a694-32dda0e3d45a.png">
