### PR TITLE
Bug - Fix bug of duration feature for model benchmarks in distributed mode.

### DIFF
--- a/superbench/benchmarks/model_benchmarks/model_base.py
+++ b/superbench/benchmarks/model_benchmarks/model_base.py
@@ -361,8 +361,6 @@ class ModelBenchmark(Benchmark):
             (self._args.duration > 0 and (curr_time - self._sub_benchmark_start_time) >= self._args.duration)
             or (total_steps > 0 and curr_step >= total_steps)
         ):
-            if self._args.duration > 0:
-                logger.info('Duration end - curr_step:{}, rank:{}.'.format(curr_step, self._local_rank))
             return True
 
         return False

--- a/superbench/benchmarks/model_benchmarks/model_base.py
+++ b/superbench/benchmarks/model_benchmarks/model_base.py
@@ -361,6 +361,8 @@ class ModelBenchmark(Benchmark):
             (self._args.duration > 0 and (curr_time - self._sub_benchmark_start_time) >= self._args.duration)
             or (total_steps > 0 and curr_step >= total_steps)
         ):
+            if self._args.duration > 0:
+                logger.info('Duration end - curr_step:{}, rank:{}.'.format(curr_step, self._local_rank))
             return True
 
         return False

--- a/superbench/benchmarks/model_benchmarks/pytorch_base.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_base.py
@@ -288,7 +288,7 @@ class PytorchBase(ModelBenchmark):
         """
         return sum(p.numel() for p in self._model.parameters() if p.requires_grad)
 
-    def timer(self):
+    def _timer(self):
         """Returns the current time which ensures all previous CUDA events have been finished.
 
         If there is no GPU present, this defaults to `time.time()`; otherwise it will

--- a/superbench/benchmarks/model_benchmarks/pytorch_base.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_base.py
@@ -207,11 +207,9 @@ class PytorchBase(ModelBenchmark):
                 # sync is_finished in distributed mode
                 # if any rank is_finished is True, all ranks should be finished
                 if self._args.distributed_impl == DistributedImpl.DDP:
-                    result = [is_finished]
+                    tensor = torch.IntTensor([is_finished])
                     if self._args.distributed_backend == DistributedBackend.NCCL:
-                        tensor = torch.as_tensor(result).cuda()
-                    else:
-                        tensor = torch.as_tensor(result)
+                        tensor = tensor.cuda()
                     torch.distributed.all_reduce(tensor, op=torch.distributed.ReduceOp.MAX)
                     is_finished = tensor.tolist()[0]
             else:
@@ -293,8 +291,8 @@ class PytorchBase(ModelBenchmark):
     def timer(self):
         """Returns the current time which ensures all previous CUDA events have been finished.
 
-           If there is no GPU present, this defaults to`time.time()`; otherwise it will synchronize
-           CUDA before measuring the time.
+        If there is no GPU present, this defaults to `time.time()`; otherwise it will
+        synchronize CUDA before measuring the time.
 
         Returns:
             Current time in second.

--- a/superbench/benchmarks/model_benchmarks/pytorch_base.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_base.py
@@ -201,8 +201,7 @@ class PytorchBase(ModelBenchmark):
         Return:
             True if the benchmarking should be stopped.
         """
-        is_finished = super()._is_finished(curr_step, curr_time)
-        is_finished = 1 if is_finished is True else 0
+        is_finished = int(super()._is_finished(curr_step, curr_time))
         if self._args.duration > 0:
             if curr_step % check_frequency == 0:
                 # sync is_finished in distributed mode
@@ -218,7 +217,7 @@ class PytorchBase(ModelBenchmark):
             else:
                 is_finished = 0
 
-        return True if is_finished == 1 else False
+        return (is_finished == 1)
 
     def _sync_result(self, result):
         """Function to reduce the result to rank 0.

--- a/superbench/benchmarks/model_benchmarks/pytorch_base.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_base.py
@@ -5,6 +5,7 @@
 
 import os
 from datetime import timedelta
+import time
 
 import torch
 import transformers
@@ -289,3 +290,16 @@ class PytorchBase(ModelBenchmark):
             The count of trainable parameters.
         """
         return sum(p.numel() for p in self._model.parameters() if p.requires_grad)
+
+    def timer(self):
+        """Returns the current time which ensures all previous CUDA events have been finished.
+
+           If there is no GPU present, this defaults to`time.time()`; otherwise it will synchronize
+           CUDA before measuring the time.
+
+        Returns:
+            Current time in second.
+        """
+        if self._gpu_available:
+            torch.cuda.synchronize()
+        return time.time()

--- a/superbench/benchmarks/model_benchmarks/pytorch_base.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_base.py
@@ -189,12 +189,13 @@ class PytorchBase(ModelBenchmark):
 
         return True
 
-    def _is_finished(self, curr_step, curr_time):
+    def _is_finished(self, curr_step, curr_time, check_frequency=100):
         """Judge whether the benchmarking should be stopped early or not.
 
         Args:
             curr_step (int): the current benchmarking step.
             curr_time (float): the current time in seconds got from time.time().
+            check_frequency (int): the frequency (step numbers) to check if benchmark should be stopped.
 
         Return:
             True if the benchmarking should be stopped.
@@ -202,16 +203,19 @@ class PytorchBase(ModelBenchmark):
         is_finished = super()._is_finished(curr_step, curr_time)
         is_finished = 1 if is_finished is True else 0
         if self._args.duration > 0:
-            # sync is_finished in distributed mode
-            # if any rank is_finished is True, all ranks should be finished
-            if self._args.distributed_impl == DistributedImpl.DDP:
-                result = [is_finished]
-                if self._args.distributed_backend == DistributedBackend.NCCL:
-                    tensor = torch.as_tensor(result).cuda()
-                else:
-                    tensor = torch.as_tensor(result)
-                torch.distributed.all_reduce(tensor, op=torch.distributed.ReduceOp.MAX)
-                is_finished = tensor.tolist()[0]
+            if curr_step % check_frequency == 0:
+                # sync is_finished in distributed mode
+                # if any rank is_finished is True, all ranks should be finished
+                if self._args.distributed_impl == DistributedImpl.DDP:
+                    result = [is_finished]
+                    if self._args.distributed_backend == DistributedBackend.NCCL:
+                        tensor = torch.as_tensor(result).cuda()
+                    else:
+                        tensor = torch.as_tensor(result)
+                    torch.distributed.all_reduce(tensor, op=torch.distributed.ReduceOp.MAX)
+                    is_finished = tensor.tolist()[0]
+            else:
+                is_finished = 0
 
         return True if is_finished == 1 else False
 

--- a/superbench/benchmarks/model_benchmarks/pytorch_bert.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_bert.py
@@ -138,7 +138,7 @@ class PytorchBERT(PytorchBase):
         check_frequency = 100
         while True:
             for idx, sample in enumerate(self._dataloader):
-                start = self.timer()
+                start = self._timer()
                 if self._gpu_available:
                     sample = sample.cuda()
                 self._optimizer.zero_grad()
@@ -146,7 +146,7 @@ class PytorchBERT(PytorchBase):
                 loss = self._loss_fn(output, self._target)
                 loss.backward()
                 self._optimizer.step()
-                end = self.timer()
+                end = self._timer()
                 curr_step += 1
                 if curr_step > self._args.num_warmup:
                     # Save the step time of every training/inference step, unit is millisecond.
@@ -170,11 +170,11 @@ class PytorchBERT(PytorchBase):
             self._model.eval()
             while True:
                 for idx, sample in enumerate(self._dataloader):
-                    start = self.timer()
+                    start = self._timer()
                     if self._gpu_available:
                         sample = sample.cuda()
                     self._model(sample)
-                    end = self.timer()
+                    end = self._timer()
                     curr_step += 1
                     if curr_step > self._args.num_warmup:
                         # Save the step time of every training/inference step, unit is millisecond.

--- a/superbench/benchmarks/model_benchmarks/pytorch_bert.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_bert.py
@@ -135,6 +135,7 @@ class PytorchBERT(PytorchBase):
         """
         duration = []
         curr_step = 0
+        check_frequency = 100
         while True:
             for idx, sample in enumerate(self._dataloader):
                 start = self.timer()
@@ -150,7 +151,7 @@ class PytorchBERT(PytorchBase):
                 if curr_step > self._args.num_warmup:
                     # Save the step time of every training/inference step, unit is millisecond.
                     duration.append((end - start) * 1000)
-                if self._is_finished(curr_step, end, 100):
+                if self._is_finished(curr_step, end, check_frequency):
                     return duration
 
     def _inference_step(self, precision):

--- a/superbench/benchmarks/model_benchmarks/pytorch_bert.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_bert.py
@@ -147,6 +147,8 @@ class PytorchBERT(PytorchBase):
                 loss = self._loss_fn(output, self._target)
                 loss.backward()
                 self._optimizer.step()
+                if self._gpu_available:
+                    torch.cuda.synchronize()
                 end = time.time()
                 curr_step += 1
                 if curr_step > self._args.num_warmup:

--- a/superbench/benchmarks/model_benchmarks/pytorch_bert.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_bert.py
@@ -3,8 +3,6 @@
 
 """Module of the Pytorch BERT model."""
 
-import time
-
 import torch
 from transformers import BertModel, BertConfig
 
@@ -139,9 +137,7 @@ class PytorchBERT(PytorchBase):
         curr_step = 0
         while True:
             for idx, sample in enumerate(self._dataloader):
-                if self._gpu_available:
-                    torch.cuda.synchronize()
-                start = time.time()
+                start = self.timer()
                 if self._gpu_available:
                     sample = sample.cuda()
                 self._optimizer.zero_grad()
@@ -149,9 +145,7 @@ class PytorchBERT(PytorchBase):
                 loss = self._loss_fn(output, self._target)
                 loss.backward()
                 self._optimizer.step()
-                if self._gpu_available:
-                    torch.cuda.synchronize()
-                end = time.time()
+                end = self.timer()
                 curr_step += 1
                 if curr_step > self._args.num_warmup:
                     # Save the step time of every training/inference step, unit is millisecond.
@@ -175,15 +169,11 @@ class PytorchBERT(PytorchBase):
             self._model.eval()
             while True:
                 for idx, sample in enumerate(self._dataloader):
-                    if self._gpu_available:
-                        torch.cuda.synchronize()
-                    start = time.time()
+                    start = self.timer()
                     if self._gpu_available:
                         sample = sample.cuda()
                     self._model(sample)
-                    if self._gpu_available:
-                        torch.cuda.synchronize()
-                    end = time.time()
+                    end = self.timer()
                     curr_step += 1
                     if curr_step > self._args.num_warmup:
                         # Save the step time of every training/inference step, unit is millisecond.

--- a/superbench/benchmarks/model_benchmarks/pytorch_bert.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_bert.py
@@ -139,6 +139,8 @@ class PytorchBERT(PytorchBase):
         curr_step = 0
         while True:
             for idx, sample in enumerate(self._dataloader):
+                if self._gpu_available:
+                    torch.cuda.synchronize()
                 start = time.time()
                 if self._gpu_available:
                     sample = sample.cuda()
@@ -154,7 +156,7 @@ class PytorchBERT(PytorchBase):
                 if curr_step > self._args.num_warmup:
                     # Save the step time of every training/inference step, unit is millisecond.
                     duration.append((end - start) * 1000)
-                if self._is_finished(curr_step, end):
+                if self._is_finished(curr_step, end, 100):
                     return duration
 
     def _inference_step(self, precision):
@@ -173,6 +175,8 @@ class PytorchBERT(PytorchBase):
             self._model.eval()
             while True:
                 for idx, sample in enumerate(self._dataloader):
+                    if self._gpu_available:
+                        torch.cuda.synchronize()
                     start = time.time()
                     if self._gpu_available:
                         sample = sample.cuda()

--- a/superbench/benchmarks/model_benchmarks/pytorch_cnn.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_cnn.py
@@ -102,6 +102,8 @@ class PytorchCNN(PytorchBase):
         while True:
             for idx, sample in enumerate(self._dataloader):
                 sample = sample.to(dtype=getattr(torch, precision.value))
+                if self._gpu_available:
+                    torch.cuda.synchronize()
                 start = time.time()
                 if self._gpu_available:
                     sample = sample.cuda()
@@ -117,7 +119,7 @@ class PytorchCNN(PytorchBase):
                 if curr_step > self._args.num_warmup:
                     # Save the step time of every training/inference step, unit is millisecond.
                     duration.append((end - start) * 1000)
-                if self._is_finished(curr_step, end):
+                if self._is_finished(curr_step, end, 100):
                     return duration
 
     def _inference_step(self, precision):
@@ -137,6 +139,8 @@ class PytorchCNN(PytorchBase):
             while True:
                 for idx, sample in enumerate(self._dataloader):
                     sample = sample.to(dtype=getattr(torch, precision.value))
+                    if self._gpu_available:
+                        torch.cuda.synchronize()
                     start = time.time()
                     if self._gpu_available:
                         sample = sample.cuda()

--- a/superbench/benchmarks/model_benchmarks/pytorch_cnn.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_cnn.py
@@ -101,7 +101,7 @@ class PytorchCNN(PytorchBase):
         while True:
             for idx, sample in enumerate(self._dataloader):
                 sample = sample.to(dtype=getattr(torch, precision.value))
-                start = self.timer()
+                start = self._timer()
                 if self._gpu_available:
                     sample = sample.cuda()
                 self._optimizer.zero_grad()
@@ -109,7 +109,7 @@ class PytorchCNN(PytorchBase):
                 loss = self._loss_fn(output, self._target)
                 loss.backward()
                 self._optimizer.step()
-                end = self.timer()
+                end = self._timer()
                 curr_step += 1
                 if curr_step > self._args.num_warmup:
                     # Save the step time of every training/inference step, unit is millisecond.
@@ -134,11 +134,11 @@ class PytorchCNN(PytorchBase):
             while True:
                 for idx, sample in enumerate(self._dataloader):
                     sample = sample.to(dtype=getattr(torch, precision.value))
-                    start = self.timer()
+                    start = self._timer()
                     if self._gpu_available:
                         sample = sample.cuda()
                     self._model(sample)
-                    end = self.timer()
+                    end = self._timer()
                     curr_step += 1
                     if curr_step > self._args.num_warmup:
                         # Save the step time of every training/inference step, unit is millisecond.

--- a/superbench/benchmarks/model_benchmarks/pytorch_cnn.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_cnn.py
@@ -97,6 +97,7 @@ class PytorchCNN(PytorchBase):
         """
         duration = []
         curr_step = 0
+        check_frequency = 100
         while True:
             for idx, sample in enumerate(self._dataloader):
                 sample = sample.to(dtype=getattr(torch, precision.value))
@@ -113,7 +114,7 @@ class PytorchCNN(PytorchBase):
                 if curr_step > self._args.num_warmup:
                     # Save the step time of every training/inference step, unit is millisecond.
                     duration.append((end - start) * 1000)
-                if self._is_finished(curr_step, end, 100):
+                if self._is_finished(curr_step, end, check_frequency):
                     return duration
 
     def _inference_step(self, precision):

--- a/superbench/benchmarks/model_benchmarks/pytorch_cnn.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_cnn.py
@@ -3,8 +3,6 @@
 
 """Module of the Pytorch CNN models."""
 
-import time
-
 import torch
 from torchvision import models
 
@@ -102,9 +100,7 @@ class PytorchCNN(PytorchBase):
         while True:
             for idx, sample in enumerate(self._dataloader):
                 sample = sample.to(dtype=getattr(torch, precision.value))
-                if self._gpu_available:
-                    torch.cuda.synchronize()
-                start = time.time()
+                start = self.timer()
                 if self._gpu_available:
                     sample = sample.cuda()
                 self._optimizer.zero_grad()
@@ -112,9 +108,7 @@ class PytorchCNN(PytorchBase):
                 loss = self._loss_fn(output, self._target)
                 loss.backward()
                 self._optimizer.step()
-                if self._gpu_available:
-                    torch.cuda.synchronize()
-                end = time.time()
+                end = self.timer()
                 curr_step += 1
                 if curr_step > self._args.num_warmup:
                     # Save the step time of every training/inference step, unit is millisecond.
@@ -139,15 +133,11 @@ class PytorchCNN(PytorchBase):
             while True:
                 for idx, sample in enumerate(self._dataloader):
                     sample = sample.to(dtype=getattr(torch, precision.value))
-                    if self._gpu_available:
-                        torch.cuda.synchronize()
-                    start = time.time()
+                    start = self.timer()
                     if self._gpu_available:
                         sample = sample.cuda()
                     self._model(sample)
-                    if self._gpu_available:
-                        torch.cuda.synchronize()
-                    end = time.time()
+                    end = self.timer()
                     curr_step += 1
                     if curr_step > self._args.num_warmup:
                         # Save the step time of every training/inference step, unit is millisecond.

--- a/superbench/benchmarks/model_benchmarks/pytorch_cnn.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_cnn.py
@@ -110,6 +110,8 @@ class PytorchCNN(PytorchBase):
                 loss = self._loss_fn(output, self._target)
                 loss.backward()
                 self._optimizer.step()
+                if self._gpu_available:
+                    torch.cuda.synchronize()
                 end = time.time()
                 curr_step += 1
                 if curr_step > self._args.num_warmup:

--- a/superbench/benchmarks/model_benchmarks/pytorch_gpt2.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_gpt2.py
@@ -3,8 +3,6 @@
 
 """Module of the Pytorch GPT2 model."""
 
-import time
-
 import torch
 from transformers import GPT2Model, GPT2Config
 
@@ -133,9 +131,7 @@ class PytorchGPT2(PytorchBase):
         curr_step = 0
         while True:
             for idx, sample in enumerate(self._dataloader):
-                if self._gpu_available:
-                    torch.cuda.synchronize()
-                start = time.time()
+                start = self.timer()
                 if self._gpu_available:
                     sample = sample.cuda()
                 self._optimizer.zero_grad()
@@ -143,9 +139,7 @@ class PytorchGPT2(PytorchBase):
                 loss = self._loss_fn(output[range(self._args.batch_size), -1], self._target)
                 loss.backward()
                 self._optimizer.step()
-                if self._gpu_available:
-                    torch.cuda.synchronize()
-                end = time.time()
+                end = self.timer()
                 curr_step += 1
                 if curr_step > self._args.num_warmup:
                     # Save the step time of every training/inference step, unit is millisecond.
@@ -169,15 +163,11 @@ class PytorchGPT2(PytorchBase):
             self._model.eval()
             while True:
                 for idx, sample in enumerate(self._dataloader):
-                    if self._gpu_available:
-                        torch.cuda.synchronize()
-                    start = time.time()
+                    start = self.timer()
                     if self._gpu_available:
                         sample = sample.cuda()
                     self._model(sample)
-                    if self._gpu_available:
-                        torch.cuda.synchronize()
-                    end = time.time()
+                    end = self.timer()
                     curr_step += 1
                     if curr_step > self._args.num_warmup:
                         # Save the step time of every training/inference step, unit is millisecond.

--- a/superbench/benchmarks/model_benchmarks/pytorch_gpt2.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_gpt2.py
@@ -132,7 +132,7 @@ class PytorchGPT2(PytorchBase):
         check_frequency = 100
         while True:
             for idx, sample in enumerate(self._dataloader):
-                start = self.timer()
+                start = self._timer()
                 if self._gpu_available:
                     sample = sample.cuda()
                 self._optimizer.zero_grad()
@@ -140,7 +140,7 @@ class PytorchGPT2(PytorchBase):
                 loss = self._loss_fn(output[range(self._args.batch_size), -1], self._target)
                 loss.backward()
                 self._optimizer.step()
-                end = self.timer()
+                end = self._timer()
                 curr_step += 1
                 if curr_step > self._args.num_warmup:
                     # Save the step time of every training/inference step, unit is millisecond.
@@ -164,11 +164,11 @@ class PytorchGPT2(PytorchBase):
             self._model.eval()
             while True:
                 for idx, sample in enumerate(self._dataloader):
-                    start = self.timer()
+                    start = self._timer()
                     if self._gpu_available:
                         sample = sample.cuda()
                     self._model(sample)
-                    end = self.timer()
+                    end = self._timer()
                     curr_step += 1
                     if curr_step > self._args.num_warmup:
                         # Save the step time of every training/inference step, unit is millisecond.

--- a/superbench/benchmarks/model_benchmarks/pytorch_gpt2.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_gpt2.py
@@ -129,6 +129,7 @@ class PytorchGPT2(PytorchBase):
         """
         duration = []
         curr_step = 0
+        check_frequency = 100
         while True:
             for idx, sample in enumerate(self._dataloader):
                 start = self.timer()
@@ -144,7 +145,7 @@ class PytorchGPT2(PytorchBase):
                 if curr_step > self._args.num_warmup:
                     # Save the step time of every training/inference step, unit is millisecond.
                     duration.append((end - start) * 1000)
-                if self._is_finished(curr_step, end, 100):
+                if self._is_finished(curr_step, end, check_frequency):
                     return duration
 
     def _inference_step(self, precision):

--- a/superbench/benchmarks/model_benchmarks/pytorch_gpt2.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_gpt2.py
@@ -141,6 +141,8 @@ class PytorchGPT2(PytorchBase):
                 loss = self._loss_fn(output[range(self._args.batch_size), -1], self._target)
                 loss.backward()
                 self._optimizer.step()
+                if self._gpu_available:
+                    torch.cuda.synchronize()
                 end = time.time()
                 curr_step += 1
                 if curr_step > self._args.num_warmup:

--- a/superbench/benchmarks/model_benchmarks/pytorch_gpt2.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_gpt2.py
@@ -133,6 +133,8 @@ class PytorchGPT2(PytorchBase):
         curr_step = 0
         while True:
             for idx, sample in enumerate(self._dataloader):
+                if self._gpu_available:
+                    torch.cuda.synchronize()
                 start = time.time()
                 if self._gpu_available:
                     sample = sample.cuda()
@@ -148,7 +150,7 @@ class PytorchGPT2(PytorchBase):
                 if curr_step > self._args.num_warmup:
                     # Save the step time of every training/inference step, unit is millisecond.
                     duration.append((end - start) * 1000)
-                if self._is_finished(curr_step, end):
+                if self._is_finished(curr_step, end, 100):
                     return duration
 
     def _inference_step(self, precision):
@@ -167,6 +169,8 @@ class PytorchGPT2(PytorchBase):
             self._model.eval()
             while True:
                 for idx, sample in enumerate(self._dataloader):
+                    if self._gpu_available:
+                        torch.cuda.synchronize()
                     start = time.time()
                     if self._gpu_available:
                         sample = sample.cuda()

--- a/superbench/benchmarks/model_benchmarks/pytorch_lstm.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_lstm.py
@@ -142,6 +142,8 @@ class PytorchLSTM(PytorchBase):
         while True:
             for idx, sample in enumerate(self._dataloader):
                 sample = sample.to(dtype=getattr(torch, precision.value))
+                if self._gpu_available:
+                    torch.cuda.synchronize()
                 start = time.time()
                 if self._gpu_available:
                     sample = sample.cuda()
@@ -157,7 +159,7 @@ class PytorchLSTM(PytorchBase):
                 if curr_step > self._args.num_warmup:
                     # Save the step time of every training/inference step, unit is millisecond.
                     duration.append((end - start) * 1000)
-                if self._is_finished(curr_step, end):
+                if self._is_finished(curr_step, end, 100):
                     return duration
 
     def _inference_step(self, precision):
@@ -177,6 +179,8 @@ class PytorchLSTM(PytorchBase):
             while True:
                 for idx, sample in enumerate(self._dataloader):
                     sample = sample.to(dtype=getattr(torch, precision.value))
+                    if self._gpu_available:
+                        torch.cuda.synchronize()
                     start = time.time()
                     if self._gpu_available:
                         sample = sample.cuda()

--- a/superbench/benchmarks/model_benchmarks/pytorch_lstm.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_lstm.py
@@ -150,6 +150,8 @@ class PytorchLSTM(PytorchBase):
                 loss = self._loss_fn(output, self._target)
                 loss.backward()
                 self._optimizer.step()
+                if self._gpu_available:
+                    torch.cuda.synchronize()
                 end = time.time()
                 curr_step += 1
                 if curr_step > self._args.num_warmup:

--- a/superbench/benchmarks/model_benchmarks/pytorch_lstm.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_lstm.py
@@ -3,8 +3,6 @@
 
 """Module of the Pytorch LSTM model."""
 
-import time
-
 import torch
 
 from superbench.common.utils import logger
@@ -142,9 +140,7 @@ class PytorchLSTM(PytorchBase):
         while True:
             for idx, sample in enumerate(self._dataloader):
                 sample = sample.to(dtype=getattr(torch, precision.value))
-                if self._gpu_available:
-                    torch.cuda.synchronize()
-                start = time.time()
+                start = self.timer()
                 if self._gpu_available:
                     sample = sample.cuda()
                 self._optimizer.zero_grad()
@@ -152,9 +148,7 @@ class PytorchLSTM(PytorchBase):
                 loss = self._loss_fn(output, self._target)
                 loss.backward()
                 self._optimizer.step()
-                if self._gpu_available:
-                    torch.cuda.synchronize()
-                end = time.time()
+                end = self.timer()
                 curr_step += 1
                 if curr_step > self._args.num_warmup:
                     # Save the step time of every training/inference step, unit is millisecond.
@@ -179,15 +173,11 @@ class PytorchLSTM(PytorchBase):
             while True:
                 for idx, sample in enumerate(self._dataloader):
                     sample = sample.to(dtype=getattr(torch, precision.value))
-                    if self._gpu_available:
-                        torch.cuda.synchronize()
-                    start = time.time()
+                    start = self.timer()
                     if self._gpu_available:
                         sample = sample.cuda()
                     self._model(sample)
-                    if self._gpu_available:
-                        torch.cuda.synchronize()
-                    end = time.time()
+                    end = self.timer()
                     curr_step += 1
                     if curr_step > self._args.num_warmup:
                         # Save the step time of every training/inference step, unit is millisecond.

--- a/superbench/benchmarks/model_benchmarks/pytorch_lstm.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_lstm.py
@@ -137,6 +137,7 @@ class PytorchLSTM(PytorchBase):
         """
         duration = []
         curr_step = 0
+        check_frequency = 100
         while True:
             for idx, sample in enumerate(self._dataloader):
                 sample = sample.to(dtype=getattr(torch, precision.value))
@@ -153,7 +154,7 @@ class PytorchLSTM(PytorchBase):
                 if curr_step > self._args.num_warmup:
                     # Save the step time of every training/inference step, unit is millisecond.
                     duration.append((end - start) * 1000)
-                if self._is_finished(curr_step, end, 100):
+                if self._is_finished(curr_step, end, check_frequency):
                     return duration
 
     def _inference_step(self, precision):

--- a/superbench/benchmarks/model_benchmarks/pytorch_lstm.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_lstm.py
@@ -141,7 +141,7 @@ class PytorchLSTM(PytorchBase):
         while True:
             for idx, sample in enumerate(self._dataloader):
                 sample = sample.to(dtype=getattr(torch, precision.value))
-                start = self.timer()
+                start = self._timer()
                 if self._gpu_available:
                     sample = sample.cuda()
                 self._optimizer.zero_grad()
@@ -149,7 +149,7 @@ class PytorchLSTM(PytorchBase):
                 loss = self._loss_fn(output, self._target)
                 loss.backward()
                 self._optimizer.step()
-                end = self.timer()
+                end = self._timer()
                 curr_step += 1
                 if curr_step > self._args.num_warmup:
                     # Save the step time of every training/inference step, unit is millisecond.
@@ -174,11 +174,11 @@ class PytorchLSTM(PytorchBase):
             while True:
                 for idx, sample in enumerate(self._dataloader):
                     sample = sample.to(dtype=getattr(torch, precision.value))
-                    start = self.timer()
+                    start = self._timer()
                     if self._gpu_available:
                         sample = sample.cuda()
                     self._model(sample)
-                    end = self.timer()
+                    end = self._timer()
                     curr_step += 1
                     if curr_step > self._args.num_warmup:
                         # Save the step time of every training/inference step, unit is millisecond.

--- a/tests/benchmarks/model_benchmarks/test_pytorch_base.py
+++ b/tests/benchmarks/model_benchmarks/test_pytorch_base.py
@@ -117,7 +117,7 @@ class PytorchMNIST(PytorchBase):
         duration = []
         for idx, sample in enumerate(self._dataloader):
             sample = sample.to(dtype=getattr(torch, precision.value))
-            start = self.timer()
+            start = self._timer()
             if self._gpu_available:
                 sample = sample.cuda()
             self._optimizer.zero_grad()
@@ -125,7 +125,7 @@ class PytorchMNIST(PytorchBase):
             loss = self._loss_fn(output, self._target)
             loss.backward()
             self._optimizer.step()
-            end = self.timer()
+            end = self._timer()
             if idx % 10 == 0:
                 logger.info(
                     'Train step [{}/{} ({:.0f}%)]'.format(
@@ -152,13 +152,13 @@ class PytorchMNIST(PytorchBase):
             self._model.eval()
             for idx, sample in enumerate(self._dataloader):
                 sample = sample.to(dtype=getattr(torch, precision.value))
-                start = self.timer()
+                start = self._timer()
                 if self._gpu_available:
                     sample = sample.cuda()
                 self._model(sample)
                 if self._gpu_available:
                     torch.cuda.synchronize()
-                end = self.timer()
+                end = self._timer()
                 if idx % 10 == 0:
                     logger.info(
                         'Inference step [{}/{} ({:.0f}%)]'.format(

--- a/tests/benchmarks/model_benchmarks/test_pytorch_base.py
+++ b/tests/benchmarks/model_benchmarks/test_pytorch_base.py
@@ -3,7 +3,6 @@
 
 """Tests for BenchmarkRegistry module."""
 
-import time
 import numbers
 
 import torch

--- a/tests/benchmarks/model_benchmarks/test_pytorch_base.py
+++ b/tests/benchmarks/model_benchmarks/test_pytorch_base.py
@@ -118,7 +118,7 @@ class PytorchMNIST(PytorchBase):
         duration = []
         for idx, sample in enumerate(self._dataloader):
             sample = sample.to(dtype=getattr(torch, precision.value))
-            start = time.time()
+            start = self.timer()
             if self._gpu_available:
                 sample = sample.cuda()
             self._optimizer.zero_grad()
@@ -126,7 +126,7 @@ class PytorchMNIST(PytorchBase):
             loss = self._loss_fn(output, self._target)
             loss.backward()
             self._optimizer.step()
-            end = time.time()
+            end = self.timer()
             if idx % 10 == 0:
                 logger.info(
                     'Train step [{}/{} ({:.0f}%)]'.format(
@@ -153,13 +153,13 @@ class PytorchMNIST(PytorchBase):
             self._model.eval()
             for idx, sample in enumerate(self._dataloader):
                 sample = sample.to(dtype=getattr(torch, precision.value))
-                start = time.time()
+                start = self.timer()
                 if self._gpu_available:
                     sample = sample.cuda()
                 self._model(sample)
                 if self._gpu_available:
                     torch.cuda.synchronize()
-                end = time.time()
+                end = self.timer()
                 if idx % 10 == 0:
                     logger.info(
                         'Inference step [{}/{} ({:.0f}%)]'.format(


### PR DESCRIPTION
**Description**
Fix bug of duration feature for model benchmarks in distributed mode.

**Major Revision**
- Add all_reduce to sync the result of is_finished(the function to judge whether the model benchmark should be stopped) in each step 
  - to avoid inconsistency between different ranks to determine duration end (some rank may enter one more step and can never finish)
- Add torch.cuda.synchronize() before and after step time measuring in train_step() for all model benchmarks
  - some operations in train_step() maybe async resulting incorrect step time records (for example, lstm) 


