### PR TITLE
Support multiple IB/GPU in ib validation

### DIFF
--- a/dockerfile/cuda11.1.1.dockerfile
+++ b/dockerfile/cuda11.1.1.dockerfile
@@ -115,6 +115,10 @@ ENV PATH="${PATH}" \
     ANSIBLE_DEPRECATION_WARNINGS=FALSE \
     ANSIBLE_COLLECTIONS_PATH=/usr/share/ansible/collections
 
+RUN echo PATH="$PATH" > /etc/environment && \
+    echo LD_LIBRARY_PATH="$LD_LIBRARY_PATH" >> /etc/environment && \
+    echo SB_MICRO_PATH="$SB_MICRO_PATH" >> /etc/environment
+
 WORKDIR ${SB_HOME}
 
 ADD third_party third_party

--- a/dockerfile/rocm5.0.x.dockerfile
+++ b/dockerfile/rocm5.0.x.dockerfile
@@ -35,16 +35,17 @@ RUN apt-get update && \
     libaio-dev \
     libboost-program-options-dev \
     libcap2 \
+    libnuma-dev \
     libpci-dev \
     libtinfo5 \
     libtool \
     lshw \
     net-tools \
-    libnuma-dev \
     numactl \
     openssh-client \
     openssh-server \
     pciutils \
+    rsync \
     util-linux \
     vim \
     wget \
@@ -112,6 +113,10 @@ ENV PATH="${PATH}:/opt/rocm/hip/bin/" \
     SB_MICRO_PATH=/opt/superbench \
     ANSIBLE_DEPRECATION_WARNINGS=FALSE \
     ANSIBLE_COLLECTIONS_PATH=/usr/share/ansible/collections
+
+RUN echo PATH="$PATH" > /etc/environment && \
+    echo LD_LIBRARY_PATH="$LD_LIBRARY_PATH" >> /etc/environment && \
+    echo SB_MICRO_PATH="$SB_MICRO_PATH" >> /etc/environment
 
 WORKDIR ${SB_HOME}
 

--- a/dockerfile/rocm5.1.x.dockerfile
+++ b/dockerfile/rocm5.1.x.dockerfile
@@ -34,17 +34,18 @@ RUN apt-get update && \
     libaio-dev \
     libboost-program-options-dev \
     libcap2 \
+    libnuma-dev \
     libpci-dev \
+    libssl-dev \
     libtinfo5 \
     libtool \
     lshw \
     net-tools \
-    libnuma-dev \
-    libssl-dev \
     numactl \
     openssh-client \
     openssh-server \
     pciutils \
+    rsync \
     util-linux \
     vim \
     wget \
@@ -128,6 +129,10 @@ ENV PATH="${PATH}:/opt/rocm/hip/bin/" \
     SB_MICRO_PATH=/opt/superbench \
     ANSIBLE_DEPRECATION_WARNINGS=FALSE \
     ANSIBLE_COLLECTIONS_PATH=/usr/share/ansible/collections
+
+RUN echo PATH="$PATH" > /etc/environment && \
+    echo LD_LIBRARY_PATH="$LD_LIBRARY_PATH" >> /etc/environment && \
+    echo SB_MICRO_PATH="$SB_MICRO_PATH" >> /etc/environment
 
 WORKDIR ${SB_HOME}
 

--- a/docs/user-tutorial/benchmarks/micro-benchmarks.md
+++ b/docs/user-tutorial/benchmarks/micro-benchmarks.md
@@ -137,10 +137,10 @@ The supported percentiles are 50, 90, 95, 99, and 99.9.
 
 #### Metrics
 
-| Name                                                    | Unit      | Description                                                                 |
-|---------------------------------------------------------|-----------|-----------------------------------------------------------------------------|
-| ort-inference/{precision}_{model}_time                  | time (ms) | The mean latency to execute one batch of inference.                         |
-| ort-inference/{precision}_{model}_time_{percentile}     | time (ms) | The {percentile}th percentile latency to execute one batch of inference.    |
+| Name                                                | Unit      | Description                                                              |
+|-----------------------------------------------------|-----------|--------------------------------------------------------------------------|
+| ort-inference/{precision}_{model}_time              | time (ms) | The mean latency to execute one batch of inference.                      |
+| ort-inference/{precision}_{model}_time_{percentile} | time (ms) | The {percentile}th percentile latency to execute one batch of inference. |
 
 ### `gpu-burn`
 
@@ -151,11 +151,11 @@ Supports the use of double unit types and the use of tensor cores.
 
 #### Metrics
 
-| Name                     | Unit       | Description                                                                         |
-|--------------------------|------------|-------------------------------------------------------------------------------------|
-| gpu-burn/time            | time (s)   | The runtime for gpu-burn test.                                                      |
-| gpu-burn/gpu_[0-9]_pass  | yes/no  	  | The result of the gpu-burn test for each GPU (1: yes, 0: no).                       |
-| gpu-burn/abort           | yes/no  	  | Whether or not GPU-burn test aborted before returning GPU results (1: yes, 0: no).  |
+| Name                    | Unit     | Description                                                                        |
+|-------------------------|----------|------------------------------------------------------------------------------------|
+| gpu-burn/time           | time (s) | The runtime for gpu-burn test.                                                     |
+| gpu-burn/gpu_[0-9]_pass | yes/no   | The result of the gpu-burn test for each GPU (1: yes, 0: no).                      |
+| gpu-burn/abort          | yes/no   | Whether or not GPU-burn test aborted before returning GPU results (1: yes, 0: no). |
 
 ## Communication Benchmarks
 
@@ -304,10 +304,10 @@ Each row in the config is one round, and all pairs of nodes in a row run ib comm
 
 #### Metrics
 
-| Metrics                                                       | Unit             | Description                                                                                                                                                                                                                         |
-|---------------------------------------------------------------|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ib-traffic/${command}_${line}_${pair}_${server}_${client}_bw  | bandwidth (GB/s) | The max bandwidth of ib command (ib_write_bw, ib_send_bw, ib_read_bw) run between the ${pair}<sup>th</sup> node pair in the ${line}<sup>th</sup> line of the config, ${server} and ${client} are the hostname of server and client  |
-| ib-traffic/${command}_${line}_${pair}_${server}_${client}_lat | time (us)        | The max latency of ib command (ib_write_lat, ib_send_lat, ib_read_lat) run between the ${pair}<sup>th</sup> node pair in the ${line}<sup>th</sup> line of the config, ${server} and ${client} are the hostname of server and client |
+| Metrics                                                          | Unit             | Description                                                                                                                                                                                                                        |
+|------------------------------------------------------------------|------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ib-traffic/ib\_write\_bw\_${line}\_${pair}:${server}\_${client}  | bandwidth (GB/s) | The max bandwidth of perftest (ib_write_bw, ib_send_bw, ib_read_bw) run between the ${pair}<sup>th</sup> node pair in the ${line}<sup>th</sup> line of the config, ${server} and ${client} are the hostname of server and client.  |
+| ib-traffic/ib\_write\_lat\_${line}\_${pair}:${server}\_${client} | time (us)        | The max latency of perftest (ib_write_lat, ib_send_lat, ib_read_lat) run between the ${pair}<sup>th</sup> node pair in the ${line}<sup>th</sup> line of the config, ${server} and ${client} are the hostname of server and client. |
 
 
 ## Computation-communication Benchmarks

--- a/superbench/benchmarks/micro_benchmarks/ib_validation_performance.py
+++ b/superbench/benchmarks/micro_benchmarks/ib_validation_performance.py
@@ -39,21 +39,21 @@ class IBBenchmark(MicroBenchmarkWithInvoke):
             type=str,
             default='mlx5_0',
             required=False,
-            help='The IB device, could be mlx5_0 or mlx5_$LOCAL_RANK.',
+            help='The IB device, e.g., mlx5_0, mlx5_$LOCAL_RANK, mlx5_$((LOCAL_RANK/2)), etc.',
         )
         self._parser.add_argument(
             '--gpu_dev',
             type=str,
             default=None,
             required=False,
-            help='The GPU device, could be 0 or $LOCAL_RANK',
+            help='The GPU device, e.g., 0, $LOCAL_RANK, $((LOCAL_RANK/2)), etc.',
         )
         self._parser.add_argument(
             '--numa_dev',
             type=str,
             default=None,
             required=False,
-            help='The NUMA node to bind, could be 0 or $((LOCAL_RANK/2))',
+            help='The NUMA node to bind, e.g., 0, $LOCAL_RANK, $((LOCAL_RANK/2)), etc.',
         )
         # perftest configurations
         self._parser.add_argument(

--- a/superbench/benchmarks/micro_benchmarks/ib_validation_performance.py
+++ b/superbench/benchmarks/micro_benchmarks/ib_validation_performance.py
@@ -211,7 +211,7 @@ class IBBenchmark(MicroBenchmarkWithInvoke):
         try:
             # Read the hostfile
             if not self._args.hostfile:
-                self._args.hostfile = os.path.expanduser('~/sb-workspace/hostfile')
+                self._args.hostfile = os.path.join(os.environ.get('SB_WORKSPACE', '.'), 'hostfile')
             with open(self._args.hostfile, 'r') as f:
                 hosts = f.readlines()
             # Generate the config file if not define

--- a/superbench/benchmarks/micro_benchmarks/ib_validation_performance.py
+++ b/superbench/benchmarks/micro_benchmarks/ib_validation_performance.py
@@ -262,15 +262,16 @@ class IBBenchmark(MicroBenchmarkWithInvoke):
         if self._args.gpu_dev is not None:
             gpu = GPU()
             if gpu.vendor == 'nvidia':
-                gpu_dev = f' --use_cuda={self._args.gpu_dev}'
+                gpu_dev = f'--use_cuda={self._args.gpu_dev}'
             elif gpu.vendor == 'amd':
-                gpu_dev = f' --use_rocm={self._args.gpu_dev}'
+                gpu_dev = f'--use_rocm={self._args.gpu_dev}'
             else:
                 self._result.set_return_code(ReturnCode.INVALID_ARGUMENT)
                 logger.error('No GPU found - benchmark: {}'.format(self._name))
                 return False
         # Generate ib command params
-        command_params = f'-F -n {self._args.iters} -d {self._args.ib_dev} {msg_size}{gpu_dev} --report_gbits'
+        command_params = f'-F -n {self._args.iters} -d {self._args.ib_dev} {msg_size} {gpu_dev}'
+        command_params = f'{command_params.strip()} --report_gbits'
         return command_params
 
     def _preprocess(self):

--- a/superbench/benchmarks/micro_benchmarks/ib_validation_performance.py
+++ b/superbench/benchmarks/micro_benchmarks/ib_validation_performance.py
@@ -6,7 +6,6 @@
 import os
 
 from superbench.common.utils import logger
-from superbench.common.utils import network
 from superbench.benchmarks import BenchmarkRegistry, ReturnCode
 from superbench.common.devices import GPU
 from superbench.benchmarks.micro_benchmarks import MicroBenchmarkWithInvoke
@@ -28,7 +27,7 @@ class IBBenchmark(MicroBenchmarkWithInvoke):
             'ib_write_bw', 'ib_read_bw', 'ib_send_bw', 'ib_write_lat', 'ib_read_lat', 'ib_send_lat'
         ]
         self.__patterns = ['one-to-one', 'one-to-many', 'many-to-one']
-        self.__config_path = os.getcwd() + '/config.txt'
+        self.__config_path = os.path.join(os.getcwd(), 'config.txt')
         self.__config = []
 
     def add_parser_arguments(self):
@@ -36,59 +35,71 @@ class IBBenchmark(MicroBenchmarkWithInvoke):
         super().add_parser_arguments()
 
         self._parser.add_argument(
-            '--ib_index',
-            type=int,
-            default=0,
+            '--ib_dev',
+            type=str,
+            default='mlx5_0',
             required=False,
-            help='The index of ib device.',
+            help='The IB device, could be mlx5_0 or mlx5_$LOCAL_RANK.',
         )
+        self._parser.add_argument(
+            '--gpu_dev',
+            type=str,
+            default=None,
+            required=False,
+            help='The GPU device, could be 0 or $LOCAL_RANK',
+        )
+        self._parser.add_argument(
+            '--numa_dev',
+            type=str,
+            default=None,
+            required=False,
+            help='The NUMA node to bind, could be 0 or $((LOCAL_RANK/2))',
+        )
+        # perftest configurations
         self._parser.add_argument(
             '--iters',
             type=int,
             default=5000,
             required=False,
-            help='The iterations of running ib command',
+            help='The iterations of perftest command',
         )
         self._parser.add_argument(
             '--msg_size',
             type=int,
             default=None,
             required=False,
-            help='The message size of running ib command, e.g., 8388608.',
+            help='The message size of perftest command, e.g., 8388608.',
         )
         self._parser.add_argument(
-            '--commands',
-            type=str,
-            nargs='+',
-            default=['ib_write_bw'],
-            help='The ib command used to run, e.g., {}.'.format(' '.join(self.__support_ib_commands)),
+            '--bidirectional', action='store_true', default=False, help='Measure bidirectional bandwidth.'
         )
+        self._parser.add_argument(
+            '--command',
+            type=str,
+            default='ib_write_bw',
+            required=False,
+            help='The perftest command to use, e.g., {}.'.format(' '.join(self.__support_ib_commands)),
+        )
+        # customized configurations
         self._parser.add_argument(
             '--pattern',
             type=str,
             default='one-to-one',
-            required=False,
-            help='Test IB traffic pattern type, e.g., {}.'.format(''.join(self.__patterns)),
+            help='IB traffic pattern type, e.g., {}.'.format(''.join(self.__patterns)),
         )
         self._parser.add_argument(
             '--config',
             type=str,
             default=None,
             required=False,
-            help='The path of config file on the target machines',
-        )
-        self._parser.add_argument(
-            '--bidirectional', action='store_true', default=False, help='Measure bidirectional bandwidth.'
-        )
-        self._parser.add_argument(
-            '--gpu_index', type=int, default=None, required=False, help='Test Use GPUDirect with the gpu index.'
+            help='The path of config file on the target machines.',
         )
         self._parser.add_argument(
             '--hostfile',
             type=str,
-            default='/root/hostfile',
+            default=None,
             required=False,
-            help='The path of hostfile on the target machines',
+            help='The path of hostfile on the target machines.',
         )
 
     def __one_to_many(self, n):
@@ -191,25 +202,24 @@ class IBBenchmark(MicroBenchmarkWithInvoke):
             for line in config:
                 f.write(line + '\n')
 
-    def __prepare_config(self, node_num):
+    def __prepare_config(self):
         """Prepare and read config file.
-
-        Args:
-            node_num (int): the number of nodes.
 
         Returns:
             True if the config is not empty and valid.
         """
         try:
+            # Read the hostfile
+            if not self._args.hostfile:
+                self._args.hostfile = os.path.expanduser('~/sb-workspace/hostfile')
+            with open(self._args.hostfile, 'r') as f:
+                hosts = f.readlines()
             # Generate the config file if not define
             if self._args.config is None:
-                self.gen_traffic_pattern(node_num, self._args.pattern, self.__config_path)
+                self.gen_traffic_pattern(len(hosts), self._args.pattern, self.__config_path)
             # Use the config file defined in args
             else:
                 self.__config_path = self._args.config
-            # Read the hostfile
-            with open(self._args.hostfile, 'r') as f:
-                hosts = f.readlines()
             # Read the config file and check if it's empty and valid
             with open(self.__config_path, 'r') as f:
                 lines = f.readlines()
@@ -240,7 +250,7 @@ class IBBenchmark(MicroBenchmarkWithInvoke):
             Str of ib command params if arguments are valid, otherwise False.
         """
         # Format the ib command type
-        self._args.commands = [command.lower() for command in self._args.commands]
+        self._args.command = self._args.command.lower()
         # Add message size for ib command
         msg_size = ''
         if self._args.msg_size is None:
@@ -248,29 +258,19 @@ class IBBenchmark(MicroBenchmarkWithInvoke):
         else:
             msg_size = '-s ' + str(self._args.msg_size)
         # Add GPUDirect for ib command
-        gpu_enable = ''
-        if self._args.gpu_index is not None:
+        gpu_dev = ''
+        if self._args.gpu_dev is not None:
             gpu = GPU()
             if gpu.vendor == 'nvidia':
-                gpu_enable = ' --use_cuda={gpu_index}'.format(gpu_index=str(self._args.gpu_index))
+                gpu_dev = f' --use_cuda={self._args.gpu_dev}'
             elif gpu.vendor == 'amd':
-                gpu_enable = ' --use_rocm={gpu_index}'.format(gpu_index=str(self._args.gpu_index))
+                gpu_dev = f' --use_rocm={self._args.gpu_dev}'
             else:
                 self._result.set_return_code(ReturnCode.INVALID_ARGUMENT)
                 logger.error('No GPU found - benchmark: {}'.format(self._name))
                 return False
         # Generate ib command params
-        try:
-            command_params = '-F --iters={iter} -d {device} {size}{gpu}'.format(
-                iter=str(self._args.iters),
-                device=network.get_ib_devices()[self._args.ib_index].split(':')[0],
-                size=msg_size,
-                gpu=gpu_enable
-            )
-        except BaseException as e:
-            self._result.set_return_code(ReturnCode.MICROBENCHMARK_DEVICE_GETTING_FAILURE)
-            logger.error('Getting ib devices failure - benchmark: {}, message: {}.'.format(self._name, str(e)))
-            return False
+        command_params = f'-F -n {self._args.iters} -d {self._args.ib_dev} {msg_size}{gpu_dev} --report_gbits'
         return command_params
 
     def _preprocess(self):
@@ -282,17 +282,8 @@ class IBBenchmark(MicroBenchmarkWithInvoke):
         if not super()._preprocess():
             return False
 
-        # Check MPI environment
-        self._args.pattern = self._args.pattern.lower()
-        if os.getenv('OMPI_COMM_WORLD_SIZE'):
-            node_num = int(os.getenv('OMPI_COMM_WORLD_SIZE'))
-        else:
-            self._result.set_return_code(ReturnCode.MICROBENCHMARK_MPI_INIT_FAILURE)
-            logger.error('No MPI environment - benchmark: {}.'.format(self._name))
-            return False
-
         # Generate and check config
-        if not self.__prepare_config(node_num):
+        if not self.__prepare_config():
             return False
 
         # Prepare general params for ib commands
@@ -300,27 +291,26 @@ class IBBenchmark(MicroBenchmarkWithInvoke):
         if not command_params:
             return False
         # Generate commands
-        for ib_command in self._args.commands:
-            if ib_command not in self.__support_ib_commands:
-                self._result.set_return_code(ReturnCode.INVALID_ARGUMENT)
-                logger.error(
-                    'Unsupported ib command - benchmark: {}, command: {}, expected: {}.'.format(
-                        self._name, ib_command, ' '.join(self.__support_ib_commands)
-                    )
+        if self._args.command not in self.__support_ib_commands:
+            self._result.set_return_code(ReturnCode.INVALID_ARGUMENT)
+            logger.error(
+                'Unsupported ib command - benchmark: {}, command: {}, expected: {}.'.format(
+                    self._name, self._args.command, ' '.join(self.__support_ib_commands)
                 )
-                return False
-            else:
-                ib_command_prefix = '{command} {command_params}'.format(
-                    command=ib_command, command_params=command_params
-                )
-                if 'bw' in ib_command and self._args.bidirectional:
-                    ib_command_prefix += ' -b'
+            )
+            return False
+        else:
+            ib_command_prefix = f'{os.path.join(self._args.bin_dir, self._args.command)} {command_params}'
+            if self._args.numa_dev is not None:
+                ib_command_prefix = f'numactl -N {self._args.numa_dev} {ib_command_prefix}'
+            if 'bw' in self._args.command and self._args.bidirectional:
+                ib_command_prefix += ' -b'
 
-                command = os.path.join(self._args.bin_dir, self._bin_name)
-                command += ' --hostfile ' + self._args.hostfile
-                command += ' --cmd_prefix ' + '\"' + ib_command_prefix + '\"'
-                command += ' --input_config ' + self.__config_path
-                self._commands.append(command)
+            command = os.path.join(self._args.bin_dir, self._bin_name)
+            command += ' --hostfile ' + self._args.hostfile
+            command += ' --cmd_prefix ' + "'" + ib_command_prefix + "'"
+            command += ' --input_config ' + self.__config_path
+            self._commands.append(command)
 
         return True
 
@@ -336,7 +326,7 @@ class IBBenchmark(MicroBenchmarkWithInvoke):
         Return:
             True if the raw output string is valid and result can be extracted.
         """
-        self._result.add_raw_data('raw_output_' + self._args.commands[cmd_idx], raw_output, self._args.log_raw_data)
+        self._result.add_raw_data('raw_output_' + self._args.command, raw_output, self._args.log_raw_data)
 
         # If it's invoked by MPI and rank is not 0, no result is expected
         if os.getenv('OMPI_COMM_WORLD_RANK'):
@@ -346,10 +336,8 @@ class IBBenchmark(MicroBenchmarkWithInvoke):
 
         valid = False
         content = raw_output.splitlines()
-        line_index = 0
         config_index = 0
-        command = self._args.commands[cmd_idx]
-        suffix = command.split('_')[-1]
+        command = self._args.command
         try:
             result_index = -1
             for index, line in enumerate(content):
@@ -360,25 +348,18 @@ class IBBenchmark(MicroBenchmarkWithInvoke):
                 valid = False
             else:
                 content = content[result_index:]
-                for line in content:
-                    line = list(filter(None, line.strip().split(',')))
-                    pair_index = 0
-                    for item in line:
-                        metric = '{command}_{line}_{pair}_{host}_{suffix}'.format(
-                            command=command,
-                            line=str(line_index),
-                            pair=pair_index,
-                            host=self.__config[config_index],
-                            suffix=suffix
-                        )
-                        value = float(item)
-                        if 'bw' in command:
-                            value = value / 1000
-                        self._result.add_result(metric, value)
-                        valid = True
+                for line_index, line in enumerate(content):
+                    line_result = list(filter(None, line.strip().split(',')))
+                    for pair_index, pair_result in enumerate(line_result):
+                        rank_results = list(filter(None, pair_result.strip().split(' ')))
+                        for rank_index, rank_result in enumerate(rank_results):
+                            metric = f'{command}_{line_index}_{pair_index}:{self.__config[config_index]}:{rank_index}'
+                            value = float(rank_result)
+                            if 'bw' in command:
+                                value = value / 8.0
+                            self._result.add_result(metric, value)
+                            valid = True
                         config_index += 1
-                        pair_index += 1
-                    line_index += 1
         except Exception:
             valid = False
         if valid is False or config_index != len(self.__config):

--- a/superbench/config/azure_ndmv4.yaml
+++ b/superbench/config/azure_ndmv4.yaml
@@ -163,7 +163,12 @@ superbench:
       enable: false
       modes:
         - name: mpi
-          proc_num: 1
+          proc_num: 8
+      parameters:
+        msg_size: 8388608
+        ib_dev: mlx5_$LOCAL_RANK
+        gpu_dev: $LOCAL_RANK
+        numa_dev: $((LOCAL_RANK/2))
     gpcnet-network-test:
       enable: false
       modes:

--- a/superbench/config/azure_ndv4.yaml
+++ b/superbench/config/azure_ndv4.yaml
@@ -169,7 +169,12 @@ superbench:
       enable: false
       modes:
         - name: mpi
-          proc_num: 1
+          proc_num: 8
+      parameters:
+        msg_size: 8388608
+        ib_dev: mlx5_$LOCAL_RANK
+        gpu_dev: $LOCAL_RANK
+        numa_dev: $((LOCAL_RANK/2))
     gpcnet-network-test:
       enable: false
       modes:

--- a/superbench/config/default.yaml
+++ b/superbench/config/default.yaml
@@ -154,7 +154,12 @@ superbench:
       enable: false
       modes:
         - name: mpi
-          proc_num: 1
+          proc_num: 8
+      parameters:
+        msg_size: 8388608
+        ib_dev: mlx5_$LOCAL_RANK
+        gpu_dev: $LOCAL_RANK
+        numa_dev: $((LOCAL_RANK/2))
     gpcnet-network-test:
       enable: false
       modes:

--- a/superbench/runner/playbooks/check_env.yaml
+++ b/superbench/runner/playbooks/check_env.yaml
@@ -22,10 +22,11 @@
   vars:
     workspace: '{{ ansible_user_dir }}/sb-workspace'
     container: sb-workspace
+    skip_docker: '{{ no_docker | default(false) }}'
     sb_nodes: '{{ hostvars.values() | map(attribute="ansible_hostname") | sort }}'
     sb_env: |
       # sb env
-      HOST_WS={{ ansible_user_dir }}/sb-workspace
+      SB_WORKSPACE='{{ workspace if skip_docker else "/root" }}'
       # pytorch env
       NNODES={{ sb_nodes | length }}
       NODE_RANK={{ lookup('ansible.utils.index_of', sb_nodes, 'eq', ansible_hostname) }}

--- a/superbench/runner/runner.py
+++ b/superbench/runner/runner.py
@@ -398,7 +398,7 @@ class SuperBenchRunner():
 
         fcmd = "docker exec {env_list} sb-workspace bash -c '{command}'"
         if self._docker_config.skip:
-            fcmd = "bash -c '{env_list} && cd $HOST_WS && {command}'"
+            fcmd = "bash -c '{env_list} && cd $SB_WORKSPACE && {command}'"
         ansible_runner_config = self._ansible_client.get_shell_config(
             fcmd.format(env_list=env_list, command=self.__get_mode_command(benchmark_name, mode, timeout))
         )


### PR DESCRIPTION
**Description**

Support multiple IB/GPU devices run simultaneously in ib validation benchmark.

**Major Revisions**
- Revise ib_validation_performance.cc so that multiple processes per node could be used to launch multiple perftest commands simultaneously. For each node pair in the config, number of processes per node will run in parallel.
- Revise ib_validation_performance.py to correct file paths and adjust parameters to specify different NICs/GPUs/NUMA nodes.
- Fix env issues in Dockerfile for end-to-end test.
- Update ib-traffic configuration examples in config files.
- Update unit tests and docs accordingly.

Closes #326.