### PR TITLE
Deployment - Refine error message when GPU is not detected

### DIFF
--- a/superbench/runner/playbooks/deploy.yaml
+++ b/superbench/runner/playbooks/deploy.yaml
@@ -48,8 +48,8 @@
     - name: Print GPU Checking Result
       debug:
         msg:
-          - "NVIDIA GPU {{ 'detected' if nvidia_gpu_exist else 'not detected' }}"
-          - "AMD GPU {{ 'detected' if amd_gpu_exist else 'not detected' }}"
+          - "NVIDIA GPU {{ 'detected' if nvidia_gpu_exist else 'not detected, pls confirm nvidia_uvm kernel module is loaded and /dev/nvidia-uvm exists' }}"
+          - "AMD GPU {{ 'detected' if amd_gpu_exist else 'not detected, pls confirm amdgpu kernel module is loaded' }}"
 
 - name: Remote Deployment
   hosts: all


### PR DESCRIPTION
Refine error message when GPU is not detected.

Possible solutions if hardware exists and drivers are already installed:
* nvidia gpus:
  ```sh
  /sbin/modprobe nvidia-uvm
  D=`grep nvidia-uvm /proc/devices | awk '{print $1}'`
  mknod -m 666 /dev/nvidia-uvm c $D 0
  ```

* amd gpus
  ```sh
  modprobe amdgpu
  ```