### PR TITLE
Runner - Support node_num=1 in mpi mode

### DIFF
--- a/docs/superbench-config.mdx
+++ b/docs/superbench-config.mdx
@@ -396,7 +396,7 @@ Some attributes may only be suitable for specific mode.
 |            | `local` | `torch.distributed` | `mpi` |
 | ---------: | :-----: | :-----------------: | :---: |
 | `proc_num` |    ✓    |          ✓          |   ✓   |
-| `node_num` |    ✘    |          ✓          |   ✘   |
+| `node_num` |    ✘    |          ✓          |   ✓   |
 | `prefix`   |    ✓    |          ✘          |   ✘   |
 | `env`      |    ✓    |          ✓          |   ✓   |
 | `mca`      |    ✘    |          ✘          |   ✓   |
@@ -414,7 +414,7 @@ Each process will run an individual benchmark, how processes communicate depends
 
 ### `node_num`
 
-Node number to run in the mode. Defaults to all nodes in the run.
+Node number to run in the mode. Defaults to all nodes provided by host file in the run.
 Will be ignored in `local` mode.
 
 For example, assuming you are running model benchmark on 4 nodes,

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -168,6 +168,30 @@ class RunnerTestCase(unittest.TestCase):
                     f'sb exec --output-dir {self.sb_output_dir} -c sb.config.yaml -C superbench.enable=foo'
                 ),
             },
+            {
+                'benchmark_name':
+                'foo',
+                'mode': {
+                    'name': 'mpi',
+                    'node_num': 1,
+                    'proc_num': 8,
+                    'proc_rank': 2,
+                    'mca': {
+                        'coll_hcoll_enable': 0,
+                    },
+                    'env': {
+                        'SB_MICRO_PATH': '/sb',
+                        'FOO': 'BAR',
+                        'RANK': '{proc_rank}',
+                        'NUM': '{proc_num}',
+                    },
+                },
+                'expected_command': (
+                    'mpirun -tag-output -allow-run-as-root -host localhost:8 -bind-to numa '
+                    '-mca coll_hcoll_enable 0 -x SB_MICRO_PATH=/sb -x FOO=BAR -x RANK=2 -x NUM=8 '
+                    f'sb exec --output-dir {self.sb_output_dir} -c sb.config.yaml -C superbench.enable=foo'
+                ),
+            },
         ]
         for test_case in test_cases:
             with self.subTest(msg='Testing with case', test_case=test_case):


### PR DESCRIPTION
Support `node_num: 1` in mpi mode, so that we can run mpi benchmarks in
both 1 node and all nodes in one config by changing `node_num`.

Update docs and add test case accordingly.