### PR TITLE
Support distributed NCCL performance validation

### DIFF
--- a/docs/user-tutorial/benchmarks/micro-benchmarks.md
+++ b/docs/user-tutorial/benchmarks/micro-benchmarks.md
@@ -230,11 +230,16 @@ Measure the InfiniBand loopback verbs bandwidth, performed by
 
 #### Introduction
 
-Measure the performance of NCCL/RCCL operations,
+Measure the performance of NCCL/RCCL operations under multi nodes' traffic pattern,
 performed by [nccl-tests](https://github.com/NVIDIA/nccl-tests/tree/44df0bf010dcc95e840ca0fb7466c67cff3f1f0f)
 or [rccl-tests](https://github.com/ROCmSoftwarePlatform/rccl-tests/tree/dc1ad4853d7ec738387d42a75a58a98d7af00c7b).
 Support the following operations currently: allreduce, allgather, broadcast, reduce, reducescatter, alltoall.
 
+Support the following traffic patterns:
+* `all-nodes`, validate the NCCL/RCCL performance across all VM nodes simultaneously
+* `pair-wise`, validate the NCCL/RCCL performance across VM pairs with all possible combinations by parallelizing
+* `k-batch`, validate the NCCL/RCCL performance across VM groups with a specified batch scale
+* `topo-aware`, validate the NCCL/RCCL performance across VM pairs with different distances/hops as a quick test
 #### Metrics
 
 | Name                                   | Unit             | Description                                                 |

--- a/superbench/benchmarks/micro_benchmarks/ib_validation_performance.py
+++ b/superbench/benchmarks/micro_benchmarks/ib_validation_performance.py
@@ -6,7 +6,7 @@
 import os
 
 from superbench.common.utils import logger
-from superbench.common.utils import gen_topo_aware_config
+from superbench.common.utils import gen_topo_aware_config, gen_pair_wise_config
 from superbench.benchmarks import BenchmarkRegistry, ReturnCode
 from superbench.common.devices import GPU
 from superbench.benchmarks.micro_benchmarks import MicroBenchmarkWithInvoke
@@ -184,41 +184,6 @@ class IBBenchmark(MicroBenchmarkWithInvoke):
             config.append(row)
         return config
 
-    def __fully_one_to_one(self, n):
-        """Generate one-to-one pattern config.
-
-        One-to-one means that each participant plays every other participant once.
-        The algorithm refers circle method of Round-robin tournament in
-        https://en.wikipedia.org/wiki/Round-robin_tournament.
-        if n is even, there are a total of n-1 rounds, with n/2 pair of 2 unique participants in each round.
-        If n is odd, there will be n rounds, each with n-1/2 pairs, and one participant rotating empty in that round.
-        In each round, pair up two by two from the beginning to the middle as (begin, end),(begin+1,end-1)...
-        Then, all the participants except the beginning shift left one position, and repeat the previous step.
-
-        Args:
-            n (int): the number of participants.
-
-        Returns:
-            list: the generated config list, each item in the list is a str like "0,1;2,3".
-        """
-        config = []
-        candidates = list(range(n))
-        # Add a fake participant if n is odd
-        if n % 2 == 1:
-            candidates.append(-1)
-        count = len(candidates)
-        non_moving = [candidates[0]]
-        for _ in range(count - 1):
-            pairs = [
-                '{},{}'.format(candidates[i], candidates[count - i - 1]) for i in range(0, count // 2)
-                if candidates[i] != -1 and candidates[count - i - 1] != -1
-            ]
-            row = ';'.join(pairs)
-            config.append(row)
-            robin = candidates[2:] + candidates[1:2]
-            candidates = non_moving + robin
-        return config
-
     def gen_traffic_pattern(self, hosts, mode, config_file_path):
         """Generate traffic pattern into config file.
 
@@ -234,7 +199,7 @@ class IBBenchmark(MicroBenchmarkWithInvoke):
         elif mode == 'many-to-one':
             config = self.__many_to_one(n)
         elif mode == 'one-to-one':
-            config = self.__fully_one_to_one(n)
+            config = gen_pair_wise_config(n)
         elif mode == 'topo-aware':
             config = gen_topo_aware_config(
                 hosts, self._args.ibstat, self._args.ibnetdiscover, self._args.min_dist, self._args.max_dist

--- a/superbench/common/utils/__init__.py
+++ b/superbench/common/utils/__init__.py
@@ -9,19 +9,13 @@ from superbench.common.utils.file_handler import rotate_dir, create_sb_output_di
 from superbench.common.utils.lazy_import import LazyImport
 from superbench.common.utils.process import run_command
 from superbench.common.utils.topo_aware import gen_topo_aware_config
+from superbench.common.utils.gen_config import gen_all_nodes_config, gen_pair_wise_config, \
+    gen_k_batch_config, gen_pattern_host
 
 device_manager = LazyImport('superbench.common.utils.device_manager')
 
 __all__ = [
-    'LazyImport',
-    'SuperBenchLogger',
-    'create_sb_output_dir',
-    'device_manager',
-    'get_sb_config',
-    'get_vm_size',
-    'logger',
-    'network',
-    'rotate_dir',
-    'run_command',
-    'gen_topo_aware_config',
+    'LazyImport', 'SuperBenchLogger', 'create_sb_output_dir', 'device_manager', 'get_sb_config', 'get_vm_size',
+    'logger', 'network', 'rotate_dir', 'run_command', 'gen_topo_aware_config', 'gen_all_nodes_config',
+    'gen_pair_wise_config', 'gen_k_batch_config', 'gen_pattern_host'
 ]

--- a/superbench/common/utils/gen_config.py
+++ b/superbench/common/utils/gen_config.py
@@ -1,0 +1,140 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Utilities for pattern config."""
+from superbench.common.utils import logger
+from superbench.common.utils import gen_topo_aware_config
+
+
+def gen_all_nodes_config(n):
+    """Generate all nodes config.
+
+    Args:
+        n (int): the number of participants.
+
+    Returns:
+        list: the generated config list, each item in the list is a str like "0,1,2,3".
+    """
+    config = []
+    if n <= 0:
+        logger.error('n is not positive')
+        return config
+    config = [','.join(map(str, list(range(n))))]
+    return config
+
+
+def gen_pair_wise_config(n):
+    """Generate pair-wised VM pairs config.
+
+    One-to-one means that each participant plays every other participant once.
+    The algorithm refers circle method of Round-robin tournament in
+    https://en.wikipedia.org/wiki/Round-robin_tournament.
+    if n is even, there are a total of n-1 rounds, with n/2 pair of 2 unique participants in each round.
+    If n is odd, there will be n rounds, each with n-1/2 pairs, and one participant rotating empty in that round.
+    In each round, pair up two by two from the beginning to the middle as (begin, end),(begin+1,end-1)...
+    Then, all the participants except the beginning shift left one position, and repeat the previous step.
+
+    Args:
+        n (int): the number of participants.
+
+    Returns:
+        list: the generated config list, each item in the list is a str like "0,1;2,3".
+    """
+    config = []
+    if n <= 0:
+        logger.error('n is not positive')
+        return config
+    candidates = list(range(n))
+    # Add a fake participant if n is odd
+    if n % 2 == 1:
+        candidates.append(-1)
+    count = len(candidates)
+    non_moving = [candidates[0]]
+    for _ in range(count - 1):
+        pairs = [
+            '{},{}'.format(candidates[i], candidates[count - i - 1]) for i in range(0, count // 2)
+            if candidates[i] != -1 and candidates[count - i - 1] != -1
+        ]
+        row = ';'.join(pairs)
+        config.append(row)
+        robin = candidates[2:] + candidates[1:2]
+        candidates = non_moving + robin
+    return config
+
+
+def gen_k_batch_config(scale, n):
+    """Generate VM groups config with specified batch scale.
+
+    Args:
+        k (int): the scale of batch.
+        n (int): the number of participants.
+
+    Returns:
+        list: the generated config list, each item in the list is a str like "0,1;2,3".
+    """
+    config = []
+    if scale is None:
+        logger.error('scale is not specified')
+        return config
+    if scale <= 0 or n <= 0:
+        logger.error('scale or n is not positive')
+        return config
+    if scale > n:
+        logger.error('scale large than n')
+        return config
+
+    group = []
+    rem = n % scale
+    for i in range(0, n - rem, scale):
+        group.append(','.join(map(str, list(range(i, i + scale)))))
+    config = [';'.join(group)]
+    return config
+
+
+def covert_config_to_host(config, hostx):
+    """Convert config format to host node.
+
+    Args:
+        hosts (list): the list of VM hostnames read from hostfile.
+        config (list): the traffic pattern config.
+
+    Returns:
+        list: the host group from traffic pattern config.
+    """
+    host_group = []
+    for item in config:
+        groups = item.strip().strip(';').split(';')
+        host_list = []
+        for group in groups:
+            hosts = []
+            for index in group.split(','):
+                hosts.append(hostx[int(index)])
+            host_list.append(hosts)
+        host_group.append(host_list)
+    return host_group
+
+
+def gen_pattern_host(hosts, args):
+    """Generate traffic pattern config from specified mode.
+
+    Args:
+        hosts (list): the list of VM hostnames read from hostfile.
+        args (dir): the arguments from config yaml.
+
+    Returns:
+        list: the host group from traffic pattern config.
+    """
+    config = []
+    n = len(hosts)
+    if args.pattern == 'all-nodes':
+        config = gen_all_nodes_config(n)
+    elif args.pattern == 'pair-wise':
+        config = gen_pair_wise_config(n)
+    elif args.pattern == 'k-batch':
+        config = gen_k_batch_config(args.scale, n)
+    elif args.pattern == 'topo-aware':
+        config = gen_topo_aware_config(hosts, args.ibstat, args.ibnetdiscover, args.min_dist, args.max_dist)
+    else:
+        logger.error('Unsupported traffic pattern: {}'.format(args.pattern))
+    host_group = covert_config_to_host(config, hosts)
+    return host_group

--- a/superbench/runner/runner.py
+++ b/superbench/runner/runner.py
@@ -14,7 +14,7 @@ from natsort import natsorted
 from joblib import Parallel, delayed
 from omegaconf import ListConfig, OmegaConf
 
-from superbench.common.utils import SuperBenchLogger, logger
+from superbench.common.utils import SuperBenchLogger, logger, gen_pattern_host
 from superbench.runner.ansible import AnsibleClient
 from superbench.benchmarks import ReduceType, Reducer
 from superbench.monitor import MonitorRecord
@@ -78,7 +78,7 @@ class SuperBenchRunner():
                 elif mode.name == 'torch.distributed':
                     if not mode.proc_num:
                         self._sb_benchmarks[name].modes[idx].proc_num = 8
-                elif mode.name == 'mpi':
+                elif 'mpi' in mode.name:
                     if not mode.mca:
                         self._sb_benchmarks[name].modes[idx].mca = {
                             'pml': 'ob1',
@@ -102,13 +102,14 @@ class SuperBenchRunner():
                 return list(self._sb_config.superbench.enable)
         return [k for k, v in self._sb_benchmarks.items() if v.enable]
 
-    def __get_mode_command(self, benchmark_name, mode, timeout=None):
+    def __get_mode_command(self, benchmark_name, mode, timeout=None, hostx=None):
         """Get runner command for given mode.
 
         Args:
             benchmark_name (str): Benchmark name.
             mode (DictConfig): Runner mode.
             timeout (int): The timeout value in seconds.
+            hostx (str): The specified Host node list.
 
         Return:
             str: Runner command.
@@ -138,17 +139,19 @@ class SuperBenchRunner():
                 f' superbench.benchmarks.{benchmark_name}.parameters.distributed_impl=ddp'
                 f' superbench.benchmarks.{benchmark_name}.parameters.distributed_backend=nccl'
             )
-        elif mode.name == 'mpi':
+        elif 'mpi' in mode.name:
             mode_command = (
                 'mpirun '    # use default OpenMPI in image
                 '-tag-output '    # tag mpi output with [jobid,rank]<stdout/stderr> prefix
                 '-allow-run-as-root '    # allow mpirun to run when executed by root user
                 '{host_list} '    # use prepared hostfile and launch {proc_num} processes on each node
+                '{host}'    # specify the hosts for mpirun
                 '-bind-to numa '    # bind processes to numa
                 '{mca_list} {env_list} {command}'
             ).format(
-                host_list=f'-host localhost:{mode.proc_num}'
+                host_list='' if not hostx else f'-host localhost:{mode.proc_num}'
                 if mode.node_num == 1 else f'-hostfile hostfile -map-by ppr:{mode.proc_num}:node',
+                host='' if not hostx else '--host ' + ','.join(f'{host}:{mode.proc_num}' for host in hostx) + ' ',
                 mca_list=' '.join(f'-mca {k} {v}' for k, v in mode.mca.items()),
                 env_list=' '.join(
                     f'-x {k}={str(v).format(proc_rank=mode.proc_rank, proc_num=mode.proc_num)}'
@@ -377,7 +380,42 @@ class SuperBenchRunner():
 
         return metrics_summary
 
-    def _run_proc(self, benchmark_name, mode, vars):
+    def _prepare_config(self, args):
+        """Prepare and update config for benchmarking.
+
+        Args:
+            args (dict): the arguments from config yaml.
+
+        Returns:
+            args (dict): updated arguments from config yaml.
+        """
+        if args.name == 'mpi-parallels':
+            if not args.pattern:
+                logger.error('pattern is required for mpi-parallels mode.')
+                return args
+
+            if args.pattern == 'topo-aware' and not args.ibstat:
+                args.ibstat = self._generate_ibstat()
+        return args
+
+    def _generate_ibstat(self):
+        """Generate the ibstat file if not exist according to ansible.
+
+        Returns:
+            ibstat_file (str): path of ibstat output.
+        """
+        ibstat_file = str(self._output_path / 'ibstate_file.txt')
+        cmd = 'cat /sys/class/infiniband/*/sys_image_guid | tr -d :'
+        raw_output = self._ansible_client.run(self._ansible_client.get_shell_config(cmd), stdout=True)
+
+        with Path(ibstat_file).open(mode='w') as f:
+            for line in raw_output.splitlines():
+                if ' | CHANGED | rc=0 >>' in line:
+                    line = 'VM_hostname ' + line.replace(' | CHANGED | rc=0 >>', '').strip()
+                f.write(line + '\n')
+        return ibstat_file
+
+    def _run_proc(self, benchmark_name, mode, vars, hostx=None):
         """Run the process.
 
         Args:
@@ -407,9 +445,11 @@ class SuperBenchRunner():
         if self._docker_config.skip:
             fcmd = "bash -c '{env_list} && cd $SB_WORKSPACE && {command}'"
         ansible_runner_config = self._ansible_client.get_shell_config(
-            fcmd.format(env_list=env_list, command=self.__get_mode_command(benchmark_name, mode, timeout))
+            fcmd.format(
+                env_list=env_list, command=self.__get_mode_command(benchmark_name, mode, timeout=timeout, hostx=hostx)
+            )
         )
-        if mode.name == 'mpi' and mode.node_num != 1:
+        if 'mpi' in mode.name and mode.node_num != 1:
             ansible_runner_config = self._ansible_client.update_mpi_config(ansible_runner_config)
 
         if isinstance(timeout, int):
@@ -426,17 +466,32 @@ class SuperBenchRunner():
             if benchmark_name not in self._sb_enabled_benchmarks:
                 continue
             benchmark_config = self._sb_benchmarks[benchmark_name]
+            logger.info('benchmark_config is {}'.format(benchmark_config))
             for mode in benchmark_config.modes:
                 ansible_rc = 0
                 if mode.name == 'local':
                     rc_list = Parallel(n_jobs=mode.proc_num if mode.parallel else 1)(
-                        delayed(self._run_proc)(benchmark_name, mode, {
+                        delayed(self._run_proc)(benchmark_name, mode, vars={
                             'proc_rank': proc_rank
                         }) for proc_rank in range(mode.proc_num)
                     )
                     ansible_rc = sum(rc_list)
                 elif mode.name == 'torch.distributed' or mode.name == 'mpi':
-                    ansible_rc = self._run_proc(benchmark_name, mode, {'proc_rank': 0})
+                    ansible_rc = self._run_proc(benchmark_name, mode, vars={'proc_rank': 0})
+                elif mode.name == 'mpi-parallels':
+                    # prepare the config for specific benchmark
+                    mode = self._prepare_config(mode)
+                    hostx = self._ansible_client._host_list
+                    pattern_hostx = gen_pattern_host(list(map(str, hostx)), mode)
+                    rc_list = []
+                    for host_groups in pattern_hostx:
+                        para_rc_list = Parallel(n_jobs=len(host_groups))(
+                            delayed(self._run_proc)(benchmark_name, mode, hostx=host_group, vars={
+                                'proc_rank': 0
+                            }) for host_group in host_groups
+                        )
+                        rc_list.append(sum(para_rc_list))
+                    ansible_rc = sum(rc_list)
                 else:
                     logger.warning('Unknown mode %s.', mode.name)
                 if ansible_rc != 0:

--- a/superbench/runner/runner.py
+++ b/superbench/runner/runner.py
@@ -149,9 +149,9 @@ class SuperBenchRunner():
                 '-bind-to numa '    # bind processes to numa
                 '{mca_list} {env_list} {command}'
             ).format(
-                host_list='' if not hostx else f'-host localhost:{mode.proc_num}'
-                if mode.node_num == 1 else f'-hostfile hostfile -map-by ppr:{mode.proc_num}:node',
-                host='' if not hostx else '--host ' + ','.join(f'{host}:{mode.proc_num}' for host in hostx) + ' ',
+                host_list=f'-host localhost:{mode.proc_num}' if mode.node_num == 1 else
+                ('-hostfile hostfile ' if hostx is None else '') + f'-map-by ppr:{mode.proc_num}:node',
+                host='' if hostx is None else '--host ' + ','.join(f'{host}:{mode.proc_num}' for host in hostx) + ' ',
                 mca_list=' '.join(f'-mca {k} {v}' for k, v in mode.mca.items()),
                 env_list=' '.join(
                     f'-x {k}={str(v).format(proc_rank=mode.proc_rank, proc_num=mode.proc_num)}'

--- a/tests/benchmarks/micro_benchmarks/test_cuda_nccl_bw_performance.py
+++ b/tests/benchmarks/micro_benchmarks/test_cuda_nccl_bw_performance.py
@@ -89,20 +89,20 @@ class CudaNcclBwBenchmarkTest(BenchmarkTestCase, unittest.TestCase):
             'alltoall': alltoall,
         }
 
+        device_name = 'localhost'
         for op in raw_output.keys():
             benchmark._args.operation = op
             assert (benchmark._process_raw_result(0, raw_output[op]))
-
             for name in ['time', 'algbw', 'busbw']:
                 for size in ['8589934592', '4294967296', '2147483648', '1073741824', '536870912', '32']:
-                    metric = op + '_' + size + '_' + name
+                    metric = op + '_' + device_name + '_' + size + '_' + name
                     assert (metric in benchmark.result)
                     assert (len(benchmark.result[metric]) == 1)
                     assert (isinstance(benchmark.result[metric][0], numbers.Number))
 
-        assert (benchmark.result['allreduce_8589934592_time'][0] == 63896.0)
-        assert (benchmark.result['allreduce_8589934592_algbw'][0] == 134.44)
-        assert (benchmark.result['allreduce_8589934592_busbw'][0] == 235.26)
-        assert (benchmark.result['alltoall_8589934592_time'][0] == 33508.0)
-        assert (benchmark.result['alltoall_8589934592_algbw'][0] == 256.36)
-        assert (benchmark.result['alltoall_8589934592_busbw'][0] == 224.31)
+        assert (benchmark.result['allreduce_localhost_8589934592_time'][0] == 63896.0)
+        assert (benchmark.result['allreduce_localhost_8589934592_algbw'][0] == 134.44)
+        assert (benchmark.result['allreduce_localhost_8589934592_busbw'][0] == 235.26)
+        assert (benchmark.result['alltoall_localhost_8589934592_time'][0] == 33508.0)
+        assert (benchmark.result['alltoall_localhost_8589934592_algbw'][0] == 256.36)
+        assert (benchmark.result['alltoall_localhost_8589934592_busbw'][0] == 224.31)

--- a/tests/common/test_gen_config.py
+++ b/tests/common/test_gen_config.py
@@ -1,0 +1,40 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for traffic config generation module."""
+import unittest
+import uuid
+
+from superbench.common.utils import gen_all_nodes_config, gen_pair_wise_config, gen_k_batch_config
+
+
+def gen_hostlist(hostlist, num):
+    """Generate a fake list of specified number of hosts."""
+    hostlist.clear()
+    for i in range(0, num):
+        hostlist.append(str(uuid.uuid4()))
+
+
+class GenConfigTest(unittest.TestCase):
+    """Test the utils for generating config."""
+    def test_generate_config(self):
+        """Test the function of generating traffic pattern config."""
+        hostlist = []
+        # test under 8 nodes
+        gen_hostlist(hostlist, 8)
+        expected_all_node_config = ['0,1,2,3,4,5,6,7']
+        self.assertEqual(gen_all_nodes_config(len(hostlist)), expected_all_node_config)
+
+        expected_pair_wise_config = [
+            '0,7;1,6;2,5;3,4', '0,1;2,7;3,6;4,5', '0,2;3,1;4,7;5,6', '0,3;4,2;5,1;6,7', '0,4;5,3;6,2;7,1',
+            '0,5;6,4;7,3;1,2', '0,6;7,5;1,4;2,3'
+        ]
+        self.assertEqual(gen_pair_wise_config(len(hostlist)), expected_pair_wise_config)
+
+        expected_k_batch_config = [
+            ['0;1;2;3;4;5;6;7'], ['0,1;2,3;4,5;6,7'], ['0,1,2;3,4,5'], ['0,1,2,3;4,5,6,7'], ['0,1,2,3,4'],
+            ['0,1,2,3,4,5'], ['0,1,2,3,4,5,6'], ['0,1,2,3,4,5,6,7']
+        ]
+
+        for k in range(1, len(hostlist) + 1):
+            self.assertEqual(gen_k_batch_config(k, len(hostlist)), expected_k_batch_config[k - 1])


### PR DESCRIPTION
**Description**

Add a new mode `mpi-parallels` to support distributed benchmarks(e.g. NCCL test.)

Support the following patterns for distributed NCCL performance validation:
* `all-nodes`, validate the NCCL/RCCL performance across all VM nodes simultaneously
* `pair-wise`, validate the NCCL/RCCL performance across VM pairs with all possible combinations by parallelizing
* `k-batch`, validate the NCCL/RCCL performance across VM groups with a specified batch scale
* `topo-aware`, validate the NCCL/RCCL performance across VM pairs with different distances/hops as a quick test

