### PR TITLE
Setup update typing-extensions version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -197,6 +197,7 @@ setup(
                 'types-markdown',
                 'types-pkg_resources',
                 'types-pyyaml',
+                'typing-extensions>=3.10',
                 'vcrpy>=4.1.1',
                 'yapf==0.31.0',
             ],


### PR DESCRIPTION
**Description**
Update typing-extensions>=3.10 as recent mypy's update is failing cuda test pipeline.