### PR TITLE
Benchmarks - Fix missing include in FP8 benchmark

### DIFF
--- a/superbench/benchmarks/micro_benchmarks/cublaslt_fp8_gemm/cublaslt_utils.h
+++ b/superbench/benchmarks/micro_benchmarks/cublaslt_fp8_gemm/cublaslt_utils.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <memory>
+#include <stdexcept>
 #include <stdio.h>
 #include <vector>
 


### PR DESCRIPTION
**Description**

I couldn't build the fp8 benchmark.

`
[ 25%] Building CXX object CMakeFiles/cublaslt_utils.dir/cublaslt_utils.cc.o
In file included from <scrubbed>/superbench/benchmarks/micro_benchmarks/cublaslt_fp8_gemm/cublaslt_utils.cc:4:
<scrubbed>/superbench/benchmarks/micro_benchmarks/cublaslt_fp8_gemm/cublaslt_utils.h: In function ‘void checkCublasStatus(cublasStatus_t)’:
<scrubbed>/superbench/benchmarks/micro_benchmarks/cublaslt_fp8_gemm/cublaslt_utils.h:15:20: error: ‘logic_error’ is not a member of ‘std’
   15 |         throw std::logic_error("cuBLAS API failed");
      |                    ^~~~~~~~~~~
<scrubbed>/superbench/benchmarks/micro_benchmarks/cublaslt_fp8_gemm/cublaslt_utils.cc: In member function ‘size_t cublasLtGemm::GetAlgorithm(int, size_t)’:
<scrubbed>/superbench/benchmarks/micro_benchmarks/cublaslt_fp8_gemm/cublaslt_utils.cc:103:20: error: ‘runtime_error’ is not a member of ‘std’
  103 |         throw std::runtime_error("Unable to find any suitable algorithms");
      |                    ^~~~~~~~~~~~~
make[2]: *** [CMakeFiles/cublaslt_utils.dir/build.make:76: CMakeFiles/cublaslt_utils.dir/cublaslt_utils.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:85: CMakeFiles/cublaslt_utils.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
`

Adding stdexcept fixed this.
