### PR TITLE
Support `sb deploy` without pulling image

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -97,6 +97,7 @@ sb deploy [--docker-image]
           [--host-list]
           [--host-password]
           [--host-username]
+          [--no-pull]
           [--output-dir]
           [--private-key]
 ```
@@ -112,6 +113,7 @@ sb deploy [--docker-image]
 | `--host-list` `-l`    | `None`                  | Comma separated host list.                                                        |
 | `--host-password`     | `None`                  | Host password or key passphase if needed.                                         |
 | `--host-username`     | `None`                  | Host username if needed.                                                          |
+| `--no-pull`           | `False`                 | Skip pull and use local Docker image.                                             |
 | `--output-dir`        | `None`                  | Path to output directory, outputs/{datetime} will be used if not specified.       |
 | `--private-key`       | `None`                  | Path to private key if needed.                                                    |
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -97,7 +97,7 @@ sb deploy [--docker-image]
           [--host-list]
           [--host-password]
           [--host-username]
-          [--no-pull]
+          [--no-image-pull]
           [--output-dir]
           [--private-key]
 ```
@@ -113,7 +113,7 @@ sb deploy [--docker-image]
 | `--host-list` `-l`    | `None`                  | Comma separated host list.                                                        |
 | `--host-password`     | `None`                  | Host password or key passphase if needed.                                         |
 | `--host-username`     | `None`                  | Host username if needed.                                                          |
-| `--no-pull`           | `False`                 | Skip pull and use local Docker image.                                             |
+| `--no-image-pull`     | `False`                 | Skip pull and use local Docker image.                                             |
 | `--output-dir`        | `None`                  | Path to output directory, outputs/{datetime} will be used if not specified.       |
 | `--private-key`       | `None`                  | Path to private key if needed.                                                    |
 

--- a/superbench/benchmarks/model_benchmarks/pytorch_bert.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_bert.py
@@ -61,15 +61,18 @@ class TeBertBenchmarkModel(torch.nn.Module):
         self._embedding = torch.nn.Embedding(config.vocab_size, config.hidden_size)
         # Build BERT using nn.TransformerEncoderLayer or te.TransformerLayer
         # input shape: (seq_len, batch_size, hidden_size)
-        encoder_layer = te.TransformerLayer(
-            config.hidden_size,
-            config.intermediate_size,
-            config.num_attention_heads,
-            apply_residual_connection_post_layernorm=True,
-            output_layernorm=True,
-            layer_type='encoder',
+        self._encoder_layers = torch.nn.ModuleList(
+            [
+                te.TransformerLayer(
+                    config.hidden_size,
+                    config.intermediate_size,
+                    config.num_attention_heads,
+                    apply_residual_connection_post_layernorm=True,
+                    output_layernorm=True,
+                    layer_type='encoder',
+                ) for _ in range(config.num_hidden_layers)
+            ]
         )
-        self._encoder_layers = torch.nn.ModuleList([encoder_layer for _ in range(config.num_hidden_layers)])
         # BertPooler used in huggingface transformers
         # https://github.com/huggingface/transformers/blob/accad48e/src/transformers/models/bert/modeling_bert.py#L893
         self._pooler = torch.nn.Sequential(

--- a/superbench/cli/_commands.py
+++ b/superbench/cli/_commands.py
@@ -44,6 +44,7 @@ class SuperBenchCommandsLoader(CLICommandsLoader):
             ac.argument('docker_username', type=str, help='Docker registry username if authentication is needed.')
             ac.argument('docker_password', type=str, help='Docker registry password if authentication is needed.')
             ac.argument('no_docker', action='store_true', help='Run on host directly without Docker.')
+            ac.argument('no_pull', action='store_true', help='Skip pull and use local Docker image.')
             ac.argument(
                 'host_file', options_list=('--host-file', '-f'), type=str, help='Path to Ansible inventory host file.'
             )

--- a/superbench/cli/_commands.py
+++ b/superbench/cli/_commands.py
@@ -44,7 +44,7 @@ class SuperBenchCommandsLoader(CLICommandsLoader):
             ac.argument('docker_username', type=str, help='Docker registry username if authentication is needed.')
             ac.argument('docker_password', type=str, help='Docker registry password if authentication is needed.')
             ac.argument('no_docker', action='store_true', help='Run on host directly without Docker.')
-            ac.argument('no_pull', action='store_true', help='Skip pull and use local Docker image.')
+            ac.argument('no_image_pull', action='store_true', help='Skip pull and use local Docker image.')
             ac.argument(
                 'host_file', options_list=('--host-file', '-f'), type=str, help='Path to Ansible inventory host file.'
             )

--- a/superbench/cli/_handler.py
+++ b/superbench/cli/_handler.py
@@ -99,6 +99,7 @@ def process_runner_arguments(
     docker_username=None,
     docker_password=None,
     no_docker=False,
+    no_pull=False,
     host_file=None,
     host_list=None,
     host_username=None,
@@ -115,6 +116,7 @@ def process_runner_arguments(
         docker_username (str, optional): Docker registry username if authentication is needed. Defaults to None.
         docker_password (str, optional): Docker registry password if authentication is needed. Defaults to None.
         no_docker (bool, optional): Run on host directly without Docker. Defaults to False.
+        no_pull (bool, optional): Skip pull and use local Docker image. Defaults to False.
         host_file (str, optional): Path to Ansible inventory host file. Defaults to None.
         host_list (str, optional): Comma separated host list. Defaults to None.
         host_username (str, optional): Host username if needed. Defaults to None.
@@ -149,6 +151,7 @@ def process_runner_arguments(
             'password': docker_password,
             'registry': split_docker_domain(docker_image)[0],
             'skip': no_docker,
+            'pull': not no_pull,
         }
     )
     # Ansible config
@@ -209,6 +212,7 @@ def deploy_command_handler(
     docker_image='superbench/superbench',
     docker_username=None,
     docker_password=None,
+    no_pull=False,
     host_file=None,
     host_list=None,
     host_username=None,
@@ -228,6 +232,7 @@ def deploy_command_handler(
         docker_image (str, optional): Docker image URI. Defaults to superbench/superbench:latest.
         docker_username (str, optional): Docker registry username if authentication is needed. Defaults to None.
         docker_password (str, optional): Docker registry password if authentication is needed. Defaults to None.
+        no_pull (bool, optional): Skip pull and use local Docker image. Defaults to False.
         host_file (str, optional): Path to Ansible inventory host file. Defaults to None.
         host_list (str, optional): Comma separated host list. Defaults to None.
         host_username (str, optional): Host username if needed. Defaults to None.
@@ -243,6 +248,7 @@ def deploy_command_handler(
         docker_username=docker_username,
         docker_password=docker_password,
         no_docker=False,
+        no_pull=no_pull,
         host_file=host_file,
         host_list=host_list,
         host_username=host_username,
@@ -298,6 +304,7 @@ def run_command_handler(
         docker_username=docker_username,
         docker_password=docker_password,
         no_docker=no_docker,
+        no_pull=False,
         host_file=host_file,
         host_list=host_list,
         host_username=host_username,

--- a/superbench/cli/_handler.py
+++ b/superbench/cli/_handler.py
@@ -99,7 +99,7 @@ def process_runner_arguments(
     docker_username=None,
     docker_password=None,
     no_docker=False,
-    no_pull=False,
+    no_image_pull=False,
     host_file=None,
     host_list=None,
     host_username=None,
@@ -116,7 +116,7 @@ def process_runner_arguments(
         docker_username (str, optional): Docker registry username if authentication is needed. Defaults to None.
         docker_password (str, optional): Docker registry password if authentication is needed. Defaults to None.
         no_docker (bool, optional): Run on host directly without Docker. Defaults to False.
-        no_pull (bool, optional): Skip pull and use local Docker image. Defaults to False.
+        no_image_pull (bool, optional): Skip pull and use local Docker image. Defaults to False.
         host_file (str, optional): Path to Ansible inventory host file. Defaults to None.
         host_list (str, optional): Comma separated host list. Defaults to None.
         host_username (str, optional): Host username if needed. Defaults to None.
@@ -151,7 +151,7 @@ def process_runner_arguments(
             'password': docker_password,
             'registry': split_docker_domain(docker_image)[0],
             'skip': no_docker,
-            'pull': not no_pull,
+            'pull': not no_image_pull,
         }
     )
     # Ansible config
@@ -212,7 +212,7 @@ def deploy_command_handler(
     docker_image='superbench/superbench',
     docker_username=None,
     docker_password=None,
-    no_pull=False,
+    no_image_pull=False,
     host_file=None,
     host_list=None,
     host_username=None,
@@ -232,7 +232,7 @@ def deploy_command_handler(
         docker_image (str, optional): Docker image URI. Defaults to superbench/superbench:latest.
         docker_username (str, optional): Docker registry username if authentication is needed. Defaults to None.
         docker_password (str, optional): Docker registry password if authentication is needed. Defaults to None.
-        no_pull (bool, optional): Skip pull and use local Docker image. Defaults to False.
+        no_image_pull (bool, optional): Skip pull and use local Docker image. Defaults to False.
         host_file (str, optional): Path to Ansible inventory host file. Defaults to None.
         host_list (str, optional): Comma separated host list. Defaults to None.
         host_username (str, optional): Host username if needed. Defaults to None.
@@ -248,7 +248,7 @@ def deploy_command_handler(
         docker_username=docker_username,
         docker_password=docker_password,
         no_docker=False,
-        no_pull=no_pull,
+        no_image_pull=no_image_pull,
         host_file=host_file,
         host_list=host_list,
         host_username=host_username,
@@ -304,7 +304,7 @@ def run_command_handler(
         docker_username=docker_username,
         docker_password=docker_password,
         no_docker=no_docker,
-        no_pull=False,
+        no_image_pull=False,
         host_file=host_file,
         host_list=host_list,
         host_username=host_username,

--- a/superbench/runner/playbooks/deploy.yaml
+++ b/superbench/runner/playbooks/deploy.yaml
@@ -92,6 +92,7 @@
       shell: |
         docker pull {{ docker_image }}
       become: yes
+      when: docker_pull | default(true)
       throttle: 32
     - name: Starting Container
       shell: |

--- a/superbench/runner/runner.py
+++ b/superbench/runner/runner.py
@@ -183,6 +183,7 @@ class SuperBenchRunner():
             'ssh_port': random.randint(1 << 14, (1 << 15) - 1),
             'output_dir': str(self._output_path),
             'docker_image': self._docker_config.image,
+            'docker_pull': bool(self._docker_config.pull),
         }
         if bool(self._docker_config.username) and bool(self._docker_config.password):
             extravars.update(

--- a/tests/cli/test_sb.py
+++ b/tests/cli/test_sb.py
@@ -64,7 +64,7 @@ class SuperBenchCLIScenarioTest(ScenarioTest):
     def test_sb_deploy_skippull(self, mocked_failure_count):
         """Test sb deploy without docker pull."""
         mocked_failure_count.return_value = 0
-        self.cmd('sb deploy --host-list localhost --no-pull', checks=[NoneCheck()])
+        self.cmd('sb deploy --host-list localhost --no-image-pull', checks=[NoneCheck()])
 
     def test_sb_deploy_no_host(self):
         """Test sb deploy, no host_file or host_list provided, should fail."""

--- a/tests/cli/test_sb.py
+++ b/tests/cli/test_sb.py
@@ -60,6 +60,12 @@ class SuperBenchCLIScenarioTest(ScenarioTest):
         mocked_failure_count.return_value = 0
         self.cmd('sb deploy --host-list localhost', checks=[NoneCheck()])
 
+    @mock.patch('superbench.runner.SuperBenchRunner.get_failure_count')
+    def test_sb_deploy_skippull(self, mocked_failure_count):
+        """Test sb deploy without docker pull."""
+        mocked_failure_count.return_value = 0
+        self.cmd('sb deploy --host-list localhost --no-pull', checks=[NoneCheck()])
+
     def test_sb_deploy_no_host(self):
         """Test sb deploy, no host_file or host_list provided, should fail."""
         self.cmd('sb deploy', expect_failure=True)


### PR DESCRIPTION
Support `--no-image-pull` in `sb deploy` to skip image pull to use local cached images.