### PR TITLE
Dockerfile: Remove fixed rccl version in rocm5.1.x docker file

### DIFF
--- a/dockerfile/rocm5.1.x.dockerfile
+++ b/dockerfile/rocm5.1.x.dockerfile
@@ -114,13 +114,13 @@ RUN cd /tmp && \
     cp ./Linux/mlc /usr/local/bin/ && \
     rm -rf ./Linux mlc.tgz
 
-# Install rccl with commitid 6707a27
+# Install rccl with commitid 700b473
 RUN cd /tmp && \
     git clone https://github.com/ROCmSoftwarePlatform/rccl.git && \
-    cd rccl && git checkout 6707a27 && \
+    cd rccl && git checkout 700b473 && \
     mkdir build && cd build && \
-    CXX=/opt/rocm/bin/hipcc cmake -DCMAKE_INSTALL_PREFIX=/usr/local .. && \
-    make && make install && \
+    CXX=/opt/rocm/bin/hipcc cmake -DCMAKE_INSTALL_PREFIX=/opt/rocm/rccl .. && \
+    make -j ${NUM_MAKE_JOBS} && make install && \
     cd /tmp && \
     rm -rf rccl
 

--- a/dockerfile/rocm5.1.x.dockerfile
+++ b/dockerfile/rocm5.1.x.dockerfile
@@ -114,16 +114,6 @@ RUN cd /tmp && \
     cp ./Linux/mlc /usr/local/bin/ && \
     rm -rf ./Linux mlc.tgz
 
-# Install rccl with commitid 700b473
-RUN cd /tmp && \
-    git clone https://github.com/ROCmSoftwarePlatform/rccl.git && \
-    cd rccl && git checkout 700b473 && \
-    mkdir build && cd build && \
-    CXX=/opt/rocm/bin/hipcc cmake -DCMAKE_INSTALL_PREFIX=/opt/rocm/rccl .. && \
-    make -j ${NUM_MAKE_JOBS} && make install && \
-    cd /tmp && \
-    rm -rf rccl
-
 ENV PATH="${PATH}:/opt/rocm/hip/bin/" \
     LD_LIBRARY_PATH="/usr/local/lib/:${LD_LIBRARY_PATH}" \
     SB_HOME=/opt/superbench \


### PR DESCRIPTION
**Description**
The commit(e08b6d3a1cc32ac978182acd0be0ce197ca18e0d) installs a rccl version which is causing "undefined symbol: ncclGetLastError" while trying to import torch. Revert it to avoid the error. 
