### PR TITLE
Pin setuptools version to v65.7.0

### DIFF
--- a/.azure-pipelines/cpu-unit-test.yml
+++ b/.azure-pipelines/cpu-unit-test.yml
@@ -29,7 +29,7 @@ steps:
       echo "##vso[task.prependpath]$HOME/.local/bin"
     displayName: Export path
   - script: |
-      python3 -m pip install --upgrade pip
+      python3 -m pip install --upgrade pip setuptools==65.7
       python3 -m pip install .[test,cpuworker]
       make postinstall
     displayName: Install dependencies

--- a/.azure-pipelines/cuda-unit-test.yml
+++ b/.azure-pipelines/cuda-unit-test.yml
@@ -18,7 +18,7 @@ steps:
       echo "##vso[task.prependpath]$HOME/.local/bin"
     displayName: Export path
   - script: |
-      python3 -m pip install --upgrade pip
+      python3 -m pip install --upgrade pip setuptools==65.7
       python3 -m pip install .[test,nvworker]
       make postinstall
     displayName: Install dependencies

--- a/dockerfile/rocm5.0.x.dockerfile
+++ b/dockerfile/rocm5.0.x.dockerfile
@@ -132,7 +132,7 @@ ADD third_party third_party
 RUN make -C third_party rocm
 
 ADD . .
-RUN python3 -m pip install --upgrade setuptools && \
+RUN python3 -m pip install --upgrade setuptools==65.7 && \
     python3 -m pip install --no-cache-dir .[amdworker] && \
     make cppbuild && \
     make postinstall && \

--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,9 @@ from setuptools import setup, find_packages, Command
 import superbench
 
 try:
-    pkg_resources.require(['pip>=18', 'setuptools>=45'])
+    pkg_resources.require(['pip>=18', 'setuptools>=45, <66'])
 except (pkg_resources.VersionConflict, pkg_resources.DistributionNotFound):
-    print('Try upgrade pip/setuptools to latest version, for example, python3 -m pip install --upgrade pip setuptools')
+    print('Try update pip/setuptools versions, for example, python3 -m pip install --upgrade pip setuptools==65.7')
     raise
 
 here = pathlib.Path(__file__).parent.resolve()


### PR DESCRIPTION
Pin setuptools version to [v65.7.0](https://setuptools.pypa.io/en/latest/history.html#v65-7-0) to avoid breaking changes pypa/setuptools#2497 since v66.0.0, see pypa/setuptools#3772 for reference.