### PR TITLE
Limit ansible_runner version for Python3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -149,7 +149,7 @@ setup(
     ],
     install_requires=[
         'ansible_base>=2.10.9;os_name=="posix"',
-        'ansible_runner>=2.0.0rc1',
+        'ansible_runner>=2.0.0rc1, <2.3.2',
         'colorlog>=6.7.0',
         'importlib_metadata',
         'jinja2>=2.10.1',


### PR DESCRIPTION
Limit ansible_runner version to less than 2.3.2 for Python3.6.