### PR TITLE
Benchmarks: Bug fix - cublas cannot run all supported configs due to unsupported config's interruption for Hopper GPU

### DIFF
--- a/superbench/benchmarks/micro_benchmarks/cublas_function.py
+++ b/superbench/benchmarks/micro_benchmarks/cublas_function.py
@@ -326,14 +326,7 @@ class CublasBenchmark(MicroBenchmarkWithInvoke):
                     self._result.add_result(metric.lower() + '_time', statistics.mean(raw_data))
                     self._result.add_raw_data(metric.lower() + '_time', raw_data, self._args.log_raw_data)
                 if 'Error' in line:
-                    if self._capability == 9.0 and 'CUDNN_STATUS_NOT_SUPPORTED' in line:
-                        logger.warning(
-                            'CUDNN_STATUS_NOT_SUPPORTED error in running cublas test - round: {}, index of cmd: {}, \
-                            benchmark: {}, raw data: {}'.format(self._curr_run_index, cmd_idx, self._name, raw_output)
-                        )
-                        self._result.add_result(metric.lower() + '_time', -1)
-                    else:
-                        error = True
+                    error = True
                 if '[correctness]' in line:
                     if 'PASS' in line:
                         self._result.add_result(metric.lower() + '_correctness', 1)
@@ -349,14 +342,23 @@ class CublasBenchmark(MicroBenchmarkWithInvoke):
                     self._curr_run_index, cmd_idx, self._name, raw_output, str(e)
                 )
             )
-            return False
+            error = True
         if error:
-            logger.error(
-                'Error in running cublas test - round: {}, index of cmd: {}, benchmark: {}, raw data: {}'.format(
-                    self._curr_run_index, cmd_idx, self._name, raw_output
+            if self._capability == 9.0 and 'CUDNN_STATUS_NOT_SUPPORTED' in raw_output:
+                logger.warning(
+                    'CUDNN_STATUS_NOT_SUPPORTED error in running cublas test on Hopper GPU - round: {}, \
+                        index of cmd: {},  benchmark: {}, raw data: {}'.format(
+                        self._curr_run_index, cmd_idx, self._name, raw_output
+                    )
                 )
-            )
-            return False
+                self._result.add_result(metric.lower() + '_time', -1)
+            else:
+                logger.error(
+                    'Error in running cublas test - round: {}, index of cmd: {}, benchmark: {}, raw data: {}'.format(
+                        self._curr_run_index, cmd_idx, self._name, raw_output
+                    )
+                )
+                return False
         return True
 
 

--- a/superbench/benchmarks/micro_benchmarks/micro_base.py
+++ b/superbench/benchmarks/micro_benchmarks/micro_base.py
@@ -166,6 +166,7 @@ class MicroBenchmarkWithInvoke(MicroBenchmark):
         Return:
             True if run benchmark successfully.
         """
+        success = True
         for cmd_idx in range(len(self._commands)):
             logger.info(
                 'Execute command - round: {}, benchmark: {}, command: {}.'.format(
@@ -181,13 +182,13 @@ class MicroBenchmarkWithInvoke(MicroBenchmark):
                         self._curr_run_index, self._name, output.stdout
                     )
                 )
-                return False
+                success = False
             else:
                 if not self._process_raw_result(cmd_idx, output.stdout):
                     self._result.set_return_code(ReturnCode.MICROBENCHMARK_RESULT_PARSING_FAILURE)
-                    return False
+                    success = False
 
-        return True
+        return success
 
     @abstractmethod
     def _process_raw_result(self, cmd_idx, raw_output):


### PR DESCRIPTION
**Description**
fix bug of cublas cannot run all configs due to unsupported config's interruption for Hopper GPU.

**Major Revision**
- identify hopper arch to exclude the unsupported error
- revise micro_base to avoid termination of running the remaining commands run when one command failed

