### PR TITLE
Benchmarks - Support TE FP8 in BERT/GPT2 models

### DIFF
--- a/superbench/benchmarks/model_benchmarks/pytorch_base.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_base.py
@@ -9,6 +9,10 @@ import time
 
 import torch
 import transformers
+try:
+    import transformer_engine.pytorch as te
+except ImportError:
+    te = None
 from torch.utils.data import DataLoader
 from torch.distributed import TCPStore, PrefixStore
 
@@ -43,6 +47,40 @@ class PytorchBase(ModelBenchmark):
         """
         torch.backends.cuda.matmul.allow_tf32 = not self._args.force_fp32
         torch.backends.cudnn.allow_tf32 = not self._args.force_fp32
+
+    @torch.no_grad()
+    def _to_te_model(self, model):
+        """Convert the input model to Transformer Engine model.
+
+        Replace all Linear/LayerNorm layers.
+        Modified based on Huggingface's utils `accelerate.accelerator.convert_model`, reference:
+        https://github.com/huggingface/accelerate/blob/v0.17.1/src/accelerate/utils/transformer_engine.py#L24
+
+        Args:
+            model (torch.nn.Module): Torch model.
+        """
+        if not te:
+            return
+        for name, m in model.named_children():
+            if isinstance(m, torch.nn.Linear):
+                if any(p % 16 != 0 for p in m.weight.shape):
+                    return
+                te_m = te.Linear(m.in_features, m.out_features, bias=(m.bias is not None))
+                te_m.weight.copy_(m.weight)
+                if m.bias is not None:
+                    te_m.bias.copy_(m.bias)
+                setattr(model, name, te_m)
+            elif isinstance(m, torch.nn.LayerNorm):
+                te_m = te.LayerNorm(m.normalized_shape[0], eps=m.eps)
+                if hasattr(te_m, 'weight'):
+                    te_m.weight.copy_(m.weight)
+                    te_m.bias.copy_(m.bias)
+                else:
+                    te_m.layer_norm_weight.copy_(m.weight)
+                    te_m.layer_norm_bias.copy_(m.bias)
+                setattr(model, name, te_m)
+            else:
+                self._to_te_model(m)
 
     def _init_distributed_setting(self):
         """Initialize the distributed library and bind the worker to GPU.

--- a/superbench/benchmarks/model_benchmarks/pytorch_bert.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_bert.py
@@ -183,15 +183,15 @@ class PytorchBERT(PytorchBase):
             return False
 
         try:
+            self._model = BertBenchmarkModel(self._config, self._args.num_classes)
             if enable_fp8:
                 self._fp8_recipe = DelayedScaling(
                     fp8_format=Format[precision.name.strip('FP8_')],
                     amax_history_len=16,
                     amax_compute_algo='max',
                 )
-                self._model = TeBertBenchmarkModel(self._config, self._args.num_classes).to(dtype=torch.float16)
+                self._to_te_model(self._model.to(dtype=torch.float16))
             else:
-                self._model = BertBenchmarkModel(self._config, self._args.num_classes)
                 self._model = self._model.to(dtype=getattr(torch, precision.value))
             if self._gpu_available:
                 self._model = self._model.cuda()

--- a/superbench/benchmarks/model_benchmarks/pytorch_bert.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_bert.py
@@ -47,58 +47,6 @@ class BertBenchmarkModel(torch.nn.Module):
         return result
 
 
-class TeBertBenchmarkModel(torch.nn.Module):
-    """BERT model using Transformer Engine."""
-    def __init__(self, config, num_classes):
-        """Constructor.
-
-        Args:
-            config (BertConfig): Configurations of BERT model.
-            num_classes (int): The number of objects for classification.
-        """
-        super().__init__()
-
-        self._embedding = torch.nn.Embedding(config.vocab_size, config.hidden_size)
-        # Build BERT using nn.TransformerEncoderLayer or te.TransformerLayer
-        # input shape: (seq_len, batch_size, hidden_size)
-        self._encoder_layers = torch.nn.ModuleList(
-            [
-                te.TransformerLayer(
-                    config.hidden_size,
-                    config.intermediate_size,
-                    config.num_attention_heads,
-                    apply_residual_connection_post_layernorm=True,
-                    output_layernorm=True,
-                    layer_type='encoder',
-                ) for _ in range(config.num_hidden_layers)
-            ]
-        )
-        # BertPooler used in huggingface transformers
-        # https://github.com/huggingface/transformers/blob/accad48e/src/transformers/models/bert/modeling_bert.py#L893
-        self._pooler = torch.nn.Sequential(
-            torch.nn.Linear(config.hidden_size, config.hidden_size),
-            torch.nn.Tanh(),
-        )
-        self._linear = torch.nn.Linear(config.hidden_size, num_classes)
-
-    def forward(self, input):
-        """Forward propagation function.
-
-        Args:
-            input (torch.LongTensor): Indices of input sequence tokens in the vocabulary,
-              shape (batch_size, sequence_length).
-
-        Return:
-            out (torch.FloatTensor): Last layer hidden-state of the first token of the sequence
-              (classification token) further processed by a Linear layer, shape (batch_size, hidden_size).
-        """
-        out = self._embedding(input.movedim(0, -1))
-        for layer in self._encoder_layers:
-            out = layer(out, attention_mask=None)
-        out = self._linear(self._pooler(out.movedim(0, 1)[:, 0]))
-        return out
-
-
 class PytorchBERT(PytorchBase):
     """The BERT benchmark class."""
     def __init__(self, name, parameters=''):


### PR DESCRIPTION
Support Transformer Engine FP8 in existing PyTorch BERT/GPT2 models by converting linear/layernorm to TE layers.