### PR TITLE
Monitor - Fix the cgroup version checking logic.

### DIFF
--- a/superbench/monitor/monitor.py
+++ b/superbench/monitor/monitor.py
@@ -8,7 +8,6 @@ import time
 import glob
 import sched
 import multiprocessing
-from pathlib import Path
 
 from superbench.common.utils import logger, run_command
 from superbench.common.utils import device_manager as dm

--- a/superbench/monitor/monitor.py
+++ b/superbench/monitor/monitor.py
@@ -8,6 +8,7 @@ import time
 import glob
 import sched
 import multiprocessing
+from pathlib import Path
 
 from superbench.common.utils import logger, run_command
 from superbench.common.utils import device_manager as dm
@@ -38,16 +39,7 @@ class Monitor(multiprocessing.Process):
         self.__unit_MiByte = 1024 * 1024 * 1.0
 
         self.__output_handler = open(self.__output_file, 'a')
-
         self.__cgroup = 1
-        output = run_command('grep cgroup /proc/filesystems', quiet=True)
-        if output.returncode != 0:
-            logger.error('Failed to check the cgroup version, will assume using cgroup V1.')
-        else:
-            if 'cgroup2' in output.stdout:
-                self.__cgroup = 2
-
-        logger.info('cgroup version: {}.'.format(self.__cgroup))
 
     def __preprocess(self):
         """Preprocess/preparation operations before the monitoring.
@@ -77,13 +69,15 @@ class Monitor(multiprocessing.Process):
             container_pid = output.stdout
 
             try:
-                if self.__cgroup == 1:
-                    self._cpu_file = glob.glob('/sys/fs/cgroup/cpuacct/docker/{}*/cpuacct.stat'.format(container_id))[0]
+                cpu_file_cgroup_v1 = glob.glob('/sys/fs/cgroup/cpuacct/docker/{}*/cpuacct.stat'.format(container_id))
+                if len(cpu_file_cgroup_v1) > 0:
+                    self._cpu_file = cpu_file_cgroup_v1[0]
                     self._mem_file = glob.glob(
                         '/sys/fs/cgroup/memory/docker/{}*/memory.usage_in_bytes'.format(container_id)
                     )[0]
                     self._net_file = '/proc/{}/net/dev'.format(container_pid)
                 else:
+                    self.__cgroup = 2
                     self._cpu_file = glob.glob(
                         '/sys/fs/cgroup/system.slice/docker-{}*.scope/cpu.stat'.format(container_id)
                     )[0]
@@ -99,10 +93,12 @@ class Monitor(multiprocessing.Process):
                 )
                 return False
         else:
-            if self.__cgroup == 1:
-                self._cpu_file = '/sys/fs/cgroup/cpuacct/cpuacct.stat'
+            cpu_file_cgroup_v1 = '/sys/fs/cgroup/cpuacct/cpuacct.stat'
+            if os.path.exists(cpu_file_cgroup_v1):
+                self._cpu_file = cpu_file_cgroup_v1
                 self._mem_file = '/sys/fs/cgroup/memory/memory.usage_in_bytes'
             else:
+                self.__cgroup = 2
                 self._cpu_file = '/sys/fs/cgroup/cpu.stat'
                 self._mem_file = '/sys/fs/cgroup/memory.stat'
             self._net_file = '/proc/net/dev'


### PR DESCRIPTION
**Description**
Looks `grep cgroup /proc/filesystems` doesn't work for NDv4 whose cgroup version is v1, but the result of this command got v2 for NDv4. Instead, checking the file existence to judge the cgroup version.

