### PR TITLE
Revise Code - Fix wrong torch usage in communication wrapper for Distributed Inference Benchmark

### DIFF
--- a/superbench/benchmarks/micro_benchmarks/dist_inference.py
+++ b/superbench/benchmarks/micro_benchmarks/dist_inference.py
@@ -121,7 +121,7 @@ class DistInferenceModel(torch.nn.Module):
         Return:
             Tensor after all-gather.
         """
-        output = torch.empty([x.shape[0] * self.num_ranks] + list(x.shape[1:]))
+        output = torch.empty([x.shape[0] * self.num_ranks] + list(x.shape[1:]), dtype=x.dtype, device=x.device)
         dist.all_gather_into_tensor(output, x)
         return output
 

--- a/superbench/benchmarks/micro_benchmarks/dist_inference.py
+++ b/superbench/benchmarks/micro_benchmarks/dist_inference.py
@@ -121,7 +121,7 @@ class DistInferenceModel(torch.nn.Module):
         Return:
             Tensor after all-gather.
         """
-        output = torch.empty_like([x.shape[0] * self.num_ranks] + list(x.shape[1:]))
+        output = torch.empty([x.shape[0] * self.num_ranks] + list(x.shape[1:]))
         dist.all_gather_into_tensor(output, x)
         return output
 


### PR DESCRIPTION
**Description**
This commit fixes wrong `torch.empty_like` usage and missing dtype and device argument in communication wrappers.