### PR TITLE
ModelBenchmarks - Fix early stop logic due to num_steps.

### DIFF
--- a/docs/superbench-config.mdx
+++ b/docs/superbench-config.mdx
@@ -347,7 +347,7 @@ For Model-Benchmark, there have some parameters that can control the elapsed tim
 * num_warmup: the number of warmup step.
 * num_steps: the number of test step.
 
-If `duration > 0` and `num_warmup + num_steps > 0`, then benchmark will take the least as the elapsed time. Otherwise only one of them will take effect.
+If `duration > 0` and `num_steps > 0`, then benchmark will take the least as the elapsed time. Otherwise only one of them will take effect.
 
 ## `Mode` Schema
 

--- a/docs/superbench-config.mdx
+++ b/docs/superbench-config.mdx
@@ -344,7 +344,7 @@ There have four common parameters for all benchmarks:
 
 For Model-Benchmark, there have some parameters that can control the elapsed time.
 * duration: the elapsed time of benchmark in seconds.
-* num_warmup: the number of warmup step.
+* num_warmup: the number of warmup step, should be positive integer.
 * num_steps: the number of test step.
 
 If `duration > 0` and `num_steps > 0`, then benchmark will take the least as the elapsed time. Otherwise only one of them will take effect.

--- a/superbench/benchmarks/model_benchmarks/model_base.py
+++ b/superbench/benchmarks/model_benchmarks/model_base.py
@@ -204,6 +204,11 @@ class ModelBenchmark(Benchmark):
             )
         )
 
+        if self._args.num_warmup < 0:
+            logger.error('num_warmup should be positive integer, while {} is set.'.format(self._args.num_warmup))
+            self._result.set_return_code(ReturnCode.INVALID_ARGUMENT)
+            return False
+
         if not self._init_distributed_setting():
             self._result.set_return_code(ReturnCode.DISTRIBUTED_SETTING_INIT_FAILURE)
             return False

--- a/superbench/benchmarks/model_benchmarks/model_base.py
+++ b/superbench/benchmarks/model_benchmarks/model_base.py
@@ -374,7 +374,7 @@ class ModelBenchmark(Benchmark):
 
         if (
             (self._args.duration > 0 and (curr_time - self._sub_benchmark_start_time) >= self._args.duration)
-            or (total_steps > 0 and curr_step >= total_steps)
+            or (self._args.num_steps > 0 and curr_step >= total_steps)
         ):
             return True
 

--- a/tests/benchmarks/model_benchmarks/test_model_base.py
+++ b/tests/benchmarks/model_benchmarks/test_model_base.py
@@ -4,7 +4,6 @@
 """Tests for BenchmarkRegistry module."""
 
 import json
-import time
 
 from superbench.benchmarks import Platform, Framework, Precision, BenchmarkRegistry, BenchmarkType, ReturnCode
 from superbench.benchmarks.model_benchmarks import ModelBenchmark

--- a/tests/benchmarks/model_benchmarks/test_model_base.py
+++ b/tests/benchmarks/model_benchmarks/test_model_base.py
@@ -386,25 +386,29 @@ def test_is_finished():
     benchmark = create_benchmark('--num_warmup 32 --num_steps 128 --duration 0')
     benchmark._preprocess()
     end_time = 2
-    assert (benchmark._is_finished(50, end_time) == False)
-    assert (benchmark._is_finished(160, end_time))
+    curr_step = 50
+    assert (benchmark._is_finished(curr_step, end_time) == False)
+    curr_step = 160
+    assert (benchmark._is_finished(curr_step, end_time))
 
     # Only duration takes effect, benchmarking finish due to duration.
     benchmark = create_benchmark('--num_warmup 32 --num_steps 0 --duration 10')
     benchmark._preprocess()
     benchmark._sub_benchmark_start_time = 0
+    curr_step = 50
     end_time = 1
-    assert (benchmark._is_finished(160, end_time) == False)
+    assert (benchmark._is_finished(curr_step, end_time) == False)
     end_time = 10
-    assert (benchmark._is_finished(50, end_time))
+    assert (benchmark._is_finished(curr_step, end_time))
 
     # Both step and duration take effect.
     benchmark = create_benchmark('--num_warmup 32 --num_steps 128 --duration 10')
     benchmark._preprocess()
     # Benchmarking finish due to step.
+    curr_step = 160
     end_time = 2
-    assert (benchmark._is_finished(160, end_time))
+    assert (benchmark._is_finished(curr_step, end_time))
     # Benchmarking finish due to duration.
+    curr_step = 50
     end_time = 10
-    assert (benchmark._is_finished(50, end_time))
-
+    assert (benchmark._is_finished(curr_step, end_time))

--- a/tests/benchmarks/model_benchmarks/test_model_base.py
+++ b/tests/benchmarks/model_benchmarks/test_model_base.py
@@ -387,7 +387,7 @@ def test_is_finished():
     benchmark._preprocess()
     end_time = 2
     curr_step = 50
-    assert (benchmark._is_finished(curr_step, end_time) == False)
+    assert (benchmark._is_finished(curr_step, end_time) is False)
     curr_step = 160
     assert (benchmark._is_finished(curr_step, end_time))
 
@@ -397,7 +397,7 @@ def test_is_finished():
     benchmark._sub_benchmark_start_time = 0
     curr_step = 50
     end_time = 1
-    assert (benchmark._is_finished(curr_step, end_time) == False)
+    assert (benchmark._is_finished(curr_step, end_time) is False)
     end_time = 10
     assert (benchmark._is_finished(curr_step, end_time))
 

--- a/tests/benchmarks/model_benchmarks/test_model_base.py
+++ b/tests/benchmarks/model_benchmarks/test_model_base.py
@@ -408,25 +408,3 @@ def test_is_finished():
     end_time = 10
     assert (benchmark._is_finished(50, end_time))
 
-
-def test_check_result_format():
-    """Test interface Benchmark.__check_result_format()."""
-    # Positive case for __check_result_format().
-    benchmark = create_benchmark()
-    benchmark._preprocess()
-    assert (benchmark._benchmark())
-    assert (benchmark._Benchmark__check_result_type())
-    assert (benchmark._Benchmark__check_summarized_result())
-    assert (benchmark._Benchmark__check_raw_data())
-
-    # Negative case for __check_result_format() - change List[int] to List[str].
-    benchmark._result._BenchmarkResult__result = {'return_code': [0], 'metric1': ['2.0']}
-    assert (benchmark._Benchmark__check_summarized_result() is False)
-
-    # Negative case for __check_raw_data() - change List[List[int]] to List[List[str]].
-    benchmark._result._BenchmarkResult__raw_data = {'metric1': [['2.0']]}
-    assert (benchmark._Benchmark__check_raw_data() is False)
-
-    # Negative case for __check_raw_data() - invalid benchmark result.
-    assert (benchmark._Benchmark__check_result_format() is False)
-    assert (benchmark.return_code == ReturnCode.INVALID_BENCHMARK_RESULT)


### PR DESCRIPTION
**Description**
Model benchmarks can stop due to `num_steps` or `duration` config which will take effect when the value is set greater than 0.
If both are set greater than 0, the earliest condition reached will work.


