### PR TITLE
Doc - Update outdate references in micro-benchmarks.md

### DIFF
--- a/docs/user-tutorial/benchmarks/micro-benchmarks.md
+++ b/docs/user-tutorial/benchmarks/micro-benchmarks.md
@@ -229,7 +229,7 @@ performed by [Intel MLC Tool](https://www.intel.com/content/www/us/en/developer/
 #### Introduction
 
 Measure the memory copy bandwidth across PCI-e and memory copy bandwidth between GPUs,
-performed by [NVIDIA](https://github.com/NVIDIA/cuda-samples/tree/master/Samples/bandwidthTest)
+performed by [NVIDIA](https://github.com/NVIDIA/cuda-samples/tree/master/Samples/1_Utilities/bandwidthTest)
 or [AMD](https://github.com/ROCm-Developer-Tools/HIP/tree/master/samples/1_Utils/hipBusBandwidth) bandwidth test tool.
 
 #### Metrics


### PR DESCRIPTION
Modify link for Nvidia bandwidth test tool

**Description**
previous link is 404

**Minor Revision**
update the link value to https://github.com/NVIDIA/cuda-samples/tree/master/Samples/1_Utilities/bandwidthTest
