### PR TITLE
Bug Fix - remove cp ptx file command in gpu burn test 

### DIFF
--- a/superbench/benchmarks/micro_benchmarks/gpu_burn_test.py
+++ b/superbench/benchmarks/micro_benchmarks/gpu_burn_test.py
@@ -66,12 +66,8 @@ class GpuBurnBenchmark(MicroBenchmarkWithInvoke):
         if self._args.tensor_core:
             command += ' -tc'
         command += ' {} '.format(self._args.time)
-        # copy compare.ptx which needs to be in the working directory
-        compare_copy = 'cp ' + self._args.bin_dir + '/compare.ptx ./'
-        # remove compare.ptx from working directory
-        compare_rm = 'rm ' + 'compare.ptx'
 
-        self._commands.append(compare_copy + ' && ' + command + ' && ' + compare_rm)
+        self._commands.append(command)
 
         return True
 

--- a/tests/benchmarks/micro_benchmarks/test_gpu_burn_test.py
+++ b/tests/benchmarks/micro_benchmarks/test_gpu_burn_test.py
@@ -46,14 +46,10 @@ class GpuBurnBenchmarkTest(BenchmarkTestCase, unittest.TestCase):
         assert (benchmark._args.tensor_core)
 
         # Check command
-        compare_copy = 'cp ' + benchmark._args.bin_dir + '/compare.ptx ./'
-        compare_rm = 'rm ' + 'compare.ptx'
         assert (1 == len(benchmark._commands))
-        assert (benchmark._commands[0].startswith(compare_copy))
         assert ('-d' in benchmark._commands[0])
         assert ('-tc' in benchmark._commands[0])
         assert (str(time) in benchmark._commands[0])
-        assert (compare_rm in benchmark._commands[0])
 
         # Check results
         assert (benchmark._process_raw_result(0, results))


### PR DESCRIPTION
**Description**
remove cp ptx file in gpu burn test since the command is run inside self.args.bin_dir dir.

https://github.com/microsoft/superbenchmark/blob/d246bab430adeb461072918a551b2e2b68c9bce5/superbench/benchmarks/micro_benchmarks/micro_base.py#L183