### PR TITLE
Benchmark: Revision - Fix -O2 option passing in gpu_copy ROCm build

### DIFF
--- a/superbench/benchmarks/micro_benchmarks/gpu_copy_performance/CMakeLists.txt
+++ b/superbench/benchmarks/micro_benchmarks/gpu_copy_performance/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 
         # link hip device lib
         add_executable(gpu_copy gpu_copy.cpp)
-        add_compile_options(-O2)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2")
         target_link_libraries(gpu_copy numa hip::device)
     else()
         message(FATAL_ERROR "No CUDA or ROCm environment found.")


### PR DESCRIPTION
**Description**
`add_compile_options` will not work for ROCm build, change it to setting `CMAKE_CXX_FLAGS`.