### PR TITLE
Update omegaconf version to 2.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -198,7 +198,7 @@ setup(
                 'pydocstyle>=5.1.1',
                 'pytest-cov>=2.11.1',
                 'pytest-subtests>=0.4.0',
-                'pytest>=6.2.2',
+                'pytest>=6.2.2, <=7.4.4',
                 'types-markdown',
                 'types-pkg_resources',
                 'types-pyyaml',

--- a/setup.py
+++ b/setup.py
@@ -164,7 +164,7 @@ setup(
         'natsort>=7.1.1',
         'networkx>=2.5',
         'numpy>=1.19.2',
-        'omegaconf==2.0.6',
+        'omegaconf==2.3.0',
         'openpyxl>=3.0.7',
         'packaging>=21.0',
         'pandas>=1.1.5',

--- a/superbench/config/default.yaml
+++ b/superbench/config/default.yaml
@@ -208,6 +208,7 @@ superbench:
         batch_size: 1
         precision: int8
     megatron-gpt:
+      enable: false
       modes:
       - name: mpi
         proc_num: 1

--- a/superbench/config/default.yaml
+++ b/superbench/config/default.yaml
@@ -208,7 +208,6 @@ superbench:
         batch_size: 1
         precision: int8
     megatron-gpt:
-      enable: false
       modes:
       - name: mpi
         proc_num: 1

--- a/superbench/executor/executor.py
+++ b/superbench/executor/executor.py
@@ -228,32 +228,33 @@ class SuperBenchExecutor():
                     logger.warning('Monitor can not support CPU platform.')
 
             benchmark_real_name = benchmark_name.split(':')[0]
-            for framework in benchmark_config.frameworks or [Framework.NONE.value]:
-                if benchmark_real_name == 'model-benchmarks' or (
-                    ':' not in benchmark_name and benchmark_name.endswith('_models')
-                ):
-                    for model in benchmark_config.models:
-                        full_name = f'{benchmark_name}/{framework}-{model}'
+            if 'frameworks' in benchmark_config:
+                for framework in benchmark_config.frameworks or [Framework.NONE.value]:
+                    if benchmark_real_name == 'model-benchmarks' or (
+                        ':' not in benchmark_name and benchmark_name.endswith('_models')
+                    ):
+                        for model in benchmark_config.models:
+                            full_name = f'{benchmark_name}/{framework}-{model}'
+                            logger.info('Executor is going to execute %s.', full_name)
+                            context = BenchmarkRegistry.create_benchmark_context(
+                                model,
+                                platform=self.__get_platform(),
+                                framework=Framework(framework.lower()),
+                                parameters=self.__get_arguments(benchmark_config.parameters)
+                            )
+                            result = self.__exec_benchmark(full_name, context)
+                            benchmark_results.append(result)
+                    else:
+                        full_name = benchmark_name
                         logger.info('Executor is going to execute %s.', full_name)
                         context = BenchmarkRegistry.create_benchmark_context(
-                            model,
+                            benchmark_real_name,
                             platform=self.__get_platform(),
                             framework=Framework(framework.lower()),
                             parameters=self.__get_arguments(benchmark_config.parameters)
                         )
                         result = self.__exec_benchmark(full_name, context)
                         benchmark_results.append(result)
-                else:
-                    full_name = benchmark_name
-                    logger.info('Executor is going to execute %s.', full_name)
-                    context = BenchmarkRegistry.create_benchmark_context(
-                        benchmark_real_name,
-                        platform=self.__get_platform(),
-                        framework=Framework(framework.lower()),
-                        parameters=self.__get_arguments(benchmark_config.parameters)
-                    )
-                    result = self.__exec_benchmark(full_name, context)
-                    benchmark_results.append(result)
 
             if monitor:
                 monitor.stop()

--- a/superbench/executor/executor.py
+++ b/superbench/executor/executor.py
@@ -240,7 +240,9 @@ class SuperBenchExecutor():
                                 model,
                                 platform=self.__get_platform(),
                                 framework=Framework(framework.lower()),
-                                parameters=self.__get_arguments({} if 'parameters' not in benchmark_config else benchmark_config.parameters)
+                                parameters=self.__get_arguments(
+                                    {} if 'parameters' not in benchmark_config else benchmark_config.parameters
+                                )
                             )
                             result = self.__exec_benchmark(full_name, context)
                             benchmark_results.append(result)
@@ -251,7 +253,9 @@ class SuperBenchExecutor():
                             benchmark_real_name,
                             platform=self.__get_platform(),
                             framework=Framework(framework.lower()),
-                            parameters=self.__get_arguments({} if 'parameters' not in benchmark_config else benchmark_config.parameters)
+                            parameters=self.__get_arguments(
+                                {} if 'parameters' not in benchmark_config else benchmark_config.parameters
+                            )
                         )
                         result = self.__exec_benchmark(full_name, context)
                         benchmark_results.append(result)

--- a/superbench/executor/executor.py
+++ b/superbench/executor/executor.py
@@ -240,7 +240,7 @@ class SuperBenchExecutor():
                                 model,
                                 platform=self.__get_platform(),
                                 framework=Framework(framework.lower()),
-                                parameters=self.__get_arguments(benchmark_config.parameters)
+                                parameters=self.__get_arguments({} if 'parameters' not in benchmark_config else benchmark_config.parameters)
                             )
                             result = self.__exec_benchmark(full_name, context)
                             benchmark_results.append(result)
@@ -251,7 +251,7 @@ class SuperBenchExecutor():
                             benchmark_real_name,
                             platform=self.__get_platform(),
                             framework=Framework(framework.lower()),
-                            parameters=self.__get_arguments(benchmark_config.parameters)
+                            parameters=self.__get_arguments({} if 'parameters' not in benchmark_config else benchmark_config.parameters)
                         )
                         result = self.__exec_benchmark(full_name, context)
                         benchmark_results.append(result)

--- a/superbench/executor/executor.py
+++ b/superbench/executor/executor.py
@@ -71,13 +71,13 @@ class SuperBenchExecutor():
         Return:
             list: List of benchmarks which will be executed.
         """
-        if self._sb_config.superbench.enable:
+        if 'enable' in self._sb_config.superbench and self._sb_config.superbench.enable:
             if isinstance(self._sb_config.superbench.enable, str):
                 return [self._sb_config.superbench.enable]
             elif isinstance(self._sb_config.superbench.enable, (list, ListConfig)):
                 return list(self._sb_config.superbench.enable)
         # TODO: may exist order issue
-        return [k for k, v in self._sb_benchmarks.items() if v.enable]
+        return [k for k, v in self._sb_benchmarks.items() if 'enable' in v and v.enable]
 
     def __get_platform(self):
         """Detect runninng platform by environment."""

--- a/superbench/runner/runner.py
+++ b/superbench/runner/runner.py
@@ -105,12 +105,12 @@ class SuperBenchRunner():
         Return:
             list: List of benchmarks which will be executed.
         """
-        if self._sb_config.superbench.enable:
+        if 'enable' in self._sb_config.superbench and self._sb_config.superbench.enable:
             if isinstance(self._sb_config.superbench.enable, str):
                 return [self._sb_config.superbench.enable]
             elif isinstance(self._sb_config.superbench.enable, (list, ListConfig)):
                 return list(self._sb_config.superbench.enable)
-        return [k for k, v in self._sb_benchmarks.items() if v.enable]
+        return [k for k, v in self._sb_benchmarks.items() if 'enable' in v and v.enable]
 
     def __get_mode_command(self, benchmark_name, mode, timeout=None):
         """Get runner command for given mode.

--- a/superbench/runner/runner.py
+++ b/superbench/runner/runner.py
@@ -70,7 +70,7 @@ class SuperBenchRunner():
         if 'env' not in self._sb_config.superbench:
             self._sb_config.superbench.env = {}
         for name in self._sb_benchmarks:
-            if 'modes' not in self._sb_benchmarks[name].modes:
+            if 'modes' not in self._sb_benchmarks[name]:
                 self._sb_benchmarks[name].modes = []
             for idx, mode in enumerate(self._sb_benchmarks[name].modes):
                 if 'env' not in mode:

--- a/superbench/runner/runner.py
+++ b/superbench/runner/runner.py
@@ -206,6 +206,9 @@ class SuperBenchRunner():
         logger.info('Runner is going to get node system info.')
 
         fcmd = "docker exec sb-workspace bash -c '{command}'"
+
+        if 'skip' not in self._docker_config:
+            self._docker_config.skip = False
         if self._docker_config.skip:
             fcmd = "bash -c 'cd $SB_WORKSPACE && {command}'"
         ansible_runner_config = self._ansible_client.get_shell_config(
@@ -225,7 +228,7 @@ class SuperBenchRunner():
             self._ansible_client.get_playbook_config(
                 'check_env.yaml',
                 extravars={
-                    'no_docker': False if 'skip' not in self._docker_config else bool(self._docker_config.skip),
+                    'no_docker': False if 'skip' not in self._docker_config else self._docker_config.skip,
                     'output_dir': str(self._output_path),
                     'env': '\n'.join(f'{k}={v}' for k, v in self._sb_config.superbench.env.items()),
                 }
@@ -450,6 +453,8 @@ class SuperBenchRunner():
             timeout = max(timeout, 60)
 
         env_list = '--env-file /tmp/sb.env'
+        if 'skip' not in self._docker_config:
+            self._docker_config.skip = False
         if self._docker_config.skip:
             env_list = 'set -o allexport && source /tmp/sb.env && set +o allexport'
         for k, v in mode.env.items():

--- a/superbench/runner/runner.py
+++ b/superbench/runner/runner.py
@@ -225,7 +225,7 @@ class SuperBenchRunner():
             self._ansible_client.get_playbook_config(
                 'check_env.yaml',
                 extravars={
-                    'no_docker': bool(self._docker_config.skip),
+                    'no_docker': False if 'skip' not in self._docker_config else bool(self._docker_config.skip),
                     'output_dir': str(self._output_path),
                     'env': '\n'.join(f'{k}={v}' for k, v in self._sb_config.superbench.env.items()),
                 }

--- a/tests/executor/test_executor.py
+++ b/tests/executor/test_executor.py
@@ -44,7 +44,7 @@ class ExecutorTestCase(unittest.TestCase):
     def test_get_enabled_benchmarks_enable_none(self):
         """Test enabled benchmarks when superbench.enable is none."""
         benchmarks = self.default_config.superbench.benchmarks
-        expected_enabled_benchmarks = [x for x in benchmarks if benchmarks[x]['enable']]
+        expected_enabled_benchmarks = [x for x in benchmarks if 'enable' in benchmarks[x] and benchmarks[x]['enable']]
         self.assertListEqual(self.executor._sb_enabled, expected_enabled_benchmarks)
 
     def test_get_enabled_benchmarks_enable_str(self):


### PR DESCRIPTION
Update `omegaconf` version to [2.3.0](https://pypi.org/project/omegaconf/2.3.0/) as omegaconf 2.0.6 has a non-standard dependency specifier PyYAML>=5.1.*. pip 24.1 will enforce this behaviour change.
Discussion can be found at https://github.com/pypa/pip/issues/12063

![image](https://github.com/microsoft/superbenchmark/assets/24616097/a83fb605-2e25-481c-a797-4f38e1fe35f6)

