### PR TITLE
Limit protobuf version to be 3.20.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -168,7 +168,7 @@ setup(
         'openpyxl>=3.0.7',
         'packaging>=21.0',
         'pandas>=1.1.5',
-        'protobuf<=3.20.3'
+        'protobuf<=3.20.3',
         'pssh @ git+https://github.com/lilydjwg/pssh.git@v2.3.4',
         'pyyaml>=5.3',
         'requests>=2.27.1',

--- a/setup.py
+++ b/setup.py
@@ -168,6 +168,7 @@ setup(
         'openpyxl>=3.0.7',
         'packaging>=21.0',
         'pandas>=1.1.5',
+        'protobuf<=3.20.3'
         'pssh @ git+https://github.com/lilydjwg/pssh.git@v2.3.4',
         'pyyaml>=5.3',
         'requests>=2.27.1',


### PR DESCRIPTION
**Description**
Limit protobuf version to be 3.20.x due to onnx reqirement

<img width="1135" alt="未命名图片" src="https://github.com/user-attachments/assets/f1d52056-4697-4fb9-9fab-22f38765c53f">
