### PR TITLE
Dockerfile - upgrade nccl version and install ucx to fix bug in cuda 12.4 docker file

### DIFF
--- a/dockerfile/cuda12.4.dockerfile
+++ b/dockerfile/cuda12.4.dockerfile
@@ -123,6 +123,15 @@ RUN cd /tmp && \
     make install && \
     rm -rf /tmp/nccl
 
+# Install UCX v1.16.0 with multi-threading support
+RUN cd /tmp && \
+    wget https://github.com/openucx/ucx/releases/download/v1.16.0/ucx-1.16.0.tar.gz && \
+    tar xzf ucx-1.16.0.tar.gz && \
+    cd ucx-1.16.0 && \
+    ./contrib/configure-release-mt --prefix=/usr/local && \
+    make -j && \
+    make install
+
 ENV PATH="${PATH}" \
     LD_LIBRARY_PATH="/usr/local/lib:/usr/local/mpi/lib:${LD_LIBRARY_PATH}" \
     SB_HOME=/opt/superbench \

--- a/dockerfile/cuda12.4.dockerfile
+++ b/dockerfile/cuda12.4.dockerfile
@@ -119,7 +119,7 @@ RUN cd /tmp && \
 RUN cd /tmp && \
     git clone -b v2.23.4-1 https://github.com/NVIDIA/nccl.git && \
     cd nccl && \
-    make -j src.build && \
+    make -j ${NUM_MAKE_JOBS} src.build && \
     make install && \
     rm -rf /tmp/nccl
 
@@ -129,7 +129,7 @@ RUN cd /tmp && \
     tar xzf ucx-1.16.0.tar.gz && \
     cd ucx-1.16.0 && \
     ./contrib/configure-release-mt --prefix=/usr/local && \
-    make -j && \
+    make -j ${NUM_MAKE_JOBS} && \
     make install
 
 ENV PATH="${PATH}" \

--- a/dockerfile/cuda12.4.dockerfile
+++ b/dockerfile/cuda12.4.dockerfile
@@ -8,7 +8,7 @@ FROM nvcr.io/nvidia/pytorch:24.03-py3
 #   - CUDA: 12.4.0
 #   - cuDNN: 9.0.0.306
 #   - cuBLAS: 12.4.2.65
-#   - NCCL: v2.20
+#   - NCCL: v2.23.4-1
 #   - TransformerEngine 1.4
 # Mellanox:
 #   - OFED: 23.07-0.5.1.2
@@ -114,6 +114,14 @@ RUN cd /tmp && \
     tar xzf aocl-blis-linux-aocc-4.0.tar.gz && \
     mv amd-blis /opt/AMD && \
     rm -rf aocl-blis-linux-aocc-4.0.tar.gz
+
+# Install NCCL 2.23.4
+RUN cd /tmp && \
+    git clone -b v2.23.4-1 https://github.com/NVIDIA/nccl.git && \
+    cd nccl && \
+    make -j src.build && \
+    make install && \
+    rm -rf /tmp/nccl
 
 ENV PATH="${PATH}" \
     LD_LIBRARY_PATH="/usr/local/lib:/usr/local/mpi/lib:${LD_LIBRARY_PATH}" \


### PR DESCRIPTION
**Description**
fix bug in cuda 12.4 docker file


**Major Revision**
- upgrade nccl due to OOM bug in nccl v2.20 graph mode
- install ucx 1.16 for mutli thread support for mpi in ib-traffic
