### PR TITLE
Bug Fix - Fix numa error on grace cpu in gpu-copy

### DIFF
--- a/superbench/benchmarks/micro_benchmarks/gpu_copy_performance/gpu_copy.cu
+++ b/superbench/benchmarks/micro_benchmarks/gpu_copy_performance/gpu_copy.cu
@@ -1150,7 +1150,7 @@ int main(int argc, char **argv) {
     for (int i = 0; i < numa_count; i++) {
         args.numa_id = i;
 
-        // Avoid numa nodes without CPUS(eg. Nvidia Grace Hopper memory only numa node)
+        // Avoid numa nodes without CPUS(eg. Nvidia Grace systems have memory only numa node)
         if (!HasCPUsForNumaNode(args.numa_id)) {
             continue;
         }

--- a/superbench/benchmarks/micro_benchmarks/gpu_copy_performance/gpu_copy.cu
+++ b/superbench/benchmarks/micro_benchmarks/gpu_copy_performance/gpu_copy.cu
@@ -315,7 +315,7 @@ int SetGpu(int gpu_id) {
 
 // Check if its NUMA node has CPUs.
 bool HasCPUsForNumaNode(int node) {
-    struct bitmask *bm = numa_allocate_nodemask();
+    struct bitmask *bm = numa_allocate_cpumask();
 
     int numa_err = numa_node_to_cpus(node, bm);
     if (numa_err != 0) {
@@ -328,7 +328,7 @@ bool HasCPUsForNumaNode(int node) {
 
     // Check if any CPU is assigned to the NUMA node, has_cpus is false for mem only numa nodes
     bool has_cpus = (numa_bitmask_weight(bm) > 0);
-    numa_bitmask_free(bm);
+    numa_free_cpumask(bm);
     return has_cpus;
 }
 

--- a/superbench/benchmarks/micro_benchmarks/gpu_copy_performance/gpu_copy.cu
+++ b/superbench/benchmarks/micro_benchmarks/gpu_copy_performance/gpu_copy.cu
@@ -313,11 +313,13 @@ int SetGpu(int gpu_id) {
     return 0;
 }
 
+// Check if its NUMA node has CPUs.
 bool HasCPUsForNumaNode(int node) {
     struct bitmask *bm = numa_allocate_nodemask();
 
-    if (numa_node_to_cpus(node, bm) < 0) {
-        fprintf(stderr, "numa_node_to_cpus error on node: %d\n", node);
+    int numa_err = numa_node_to_cpus(node, bm);
+    if (numa_err != 0) {
+        fprintf(stderr, "numa_node_to_cpus error on node: %d, error code: %d\n", node, numa_err);
         numa_bitmask_free(bm);
         return false; // On error
     }

--- a/superbench/benchmarks/micro_benchmarks/gpu_copy_performance/gpu_copy.cu
+++ b/superbench/benchmarks/micro_benchmarks/gpu_copy_performance/gpu_copy.cu
@@ -3,9 +3,9 @@
 
 // GPU copy benchmark tests dtoh/htod/dtod data transfer bandwidth by GPU SM/DMA.
 
+#include <cerrno> // errno
 #include <cstdio>
 #include <cstring>
-#include <string>
 #include <vector>
 
 #include <getopt.h>
@@ -319,7 +319,9 @@ bool HasCPUsForNumaNode(int node) {
 
     int numa_err = numa_node_to_cpus(node, bm);
     if (numa_err != 0) {
-        fprintf(stderr, "numa_node_to_cpus error on node: %d, error code: %d\n", node, numa_err);
+        fprintf(stderr, "HasCPUsForNumaNode::numa_node_to_cpus error on node: %d, code: %d, message: %s\n", node, errno,
+                strerror(errno));
+
         numa_bitmask_free(bm);
         return false; // On error
     }


### PR DESCRIPTION
The current GPU Copy BW Performance fails on Nvidia Grace systems. This is due to the memory only numa node and thus the numa_run_on_node  fails for such nodes and halts completely.

This fix checks for the presence of assigned CPU cores for the numa node, on checking if it has no cpu cores assigned, it skips that specific node during the args creation and continues.