### PR TITLE
Bug - Fix tensorrt-inference parsing

### DIFF
--- a/superbench/benchmarks/micro_benchmarks/tensorrt_inference_performance.py
+++ b/superbench/benchmarks/micro_benchmarks/tensorrt_inference_performance.py
@@ -138,7 +138,7 @@ class TensorRTInferenceBenchmark(MicroBenchmarkWithInvoke):
                 line = line.strip()
                 if '[I] mean:' in line or '[I] percentile:' in line:
                     tag = 'mean' if '[I] mean:' in line else '99'
-                    lats = re.findall(r'(\d+\.\d+) ms', line)
+                    lats = re.findall(r'(\d+\.*\d*) ms', line)
                     if len(lats) == 1:
                         self._result.add_result(f'{model}_gpu_time_{tag}', float(lats[0]))
                     elif len(lats) == 2:
@@ -149,11 +149,11 @@ class TensorRTInferenceBenchmark(MicroBenchmarkWithInvoke):
                     tm = 'gpu' if '[I] GPU Compute Time:' in line else 'host'
                     self._result.add_result(
                         f'{model}_{tm}_time_mean',
-                        float(re.findall(r'mean = (\d+\.\d+) ms', line)[0]),
+                        float(re.findall(r'mean = (\d+\.*\d*) ms', line)[0]),
                     )
                     self._result.add_result(
                         f'{model}_{tm}_time_99',
-                        float(re.findall(r'\(99\%\) = (\d+\.\d+) ms', line)[0]),
+                        float(re.findall(r'\(99\%\) = (\d+\.*\d*) ms', line)[0]),
                     )
                     success = True
         except BaseException as e:


### PR DESCRIPTION
**Description**
Today I was running a benchmark on my machine. And encountered a fancy issue with tensorsort-inference.
I got code 33, which according to the source code is:
```
MICROBENCHMARK_RESULT_PARSING_FAILURE = 33
```
I dived deep into the code and found out the following problem. The parser stumbled upon getting to the following line:
```
[11/28/2024-17:03:11] [I] Latency: min = 7.2793 ms, max = 10.1606 ms, mean = 7.41642 ms, median = 7.39551 ms, percentile(99%) = 8 ms
```
I ran it separately on the code and found out that the regular expression was not suitable for the cases like this, when you encounter an INT as a result in milliseconds.
That's why this pull request is created.
I came up with the closest possible regular expression to fix this issue and not to introduce any other bug.

**Major Revision**
- 0.11.0