### PR TITLE
Update build-image with arm64

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -28,7 +28,7 @@ jobs:
         - name: cuda12.4
           dockerfile: cuda12.4
           tags: superbench/main:cuda12.4
-          platforms: linux/amd64 # TODO: linux/arm64
+          platforms: linux/amd64,linux/arm64
           runner: [self-hosted]
           build_args: "NUM_MAKE_JOBS=16"
         - name: cuda12.2


### PR DESCRIPTION
**Description**
push arm64 to hub for 12.4 onwards builds
