### PR TITLE
Flake8 repo from github

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     hooks:
       - id: mypy
         name: Check type hint using mypy
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 3.8.4
     hooks:
       - id: flake8


### PR DESCRIPTION
flake8 has moved away from gitlab to github. 
Updating the repo path int he pre commit config.