### PR TITLE
Bugfix: Avoid Unintended nvbandwidth Function Calls in All Benchmarks

### DIFF
--- a/superbench/benchmarks/micro_benchmarks/nvbandwidth.py
+++ b/superbench/benchmarks/micro_benchmarks/nvbandwidth.py
@@ -269,7 +269,14 @@ class NvBandwidthBenchmark(MicroBenchmarkWithInvoke):
 
         try:
             # Execute the command and capture output
-            result = subprocess.run(command, shell=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            result = subprocess.run(
+                command,
+                shell=True,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False
+            )
 
             # Check the return code
             if result.returncode != 0:

--- a/superbench/benchmarks/micro_benchmarks/nvbandwidth.py
+++ b/superbench/benchmarks/micro_benchmarks/nvbandwidth.py
@@ -270,12 +270,7 @@ class NvBandwidthBenchmark(MicroBenchmarkWithInvoke):
         try:
             # Execute the command and capture output
             result = subprocess.run(
-                command,
-                shell=True,
-                text=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                check=False
+                command, shell=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False
             )
 
             # Check the return code

--- a/superbench/benchmarks/micro_benchmarks/nvbandwidth.py
+++ b/superbench/benchmarks/micro_benchmarks/nvbandwidth.py
@@ -52,8 +52,8 @@ class NvBandwidthBenchmark(MicroBenchmarkWithInvoke):
             required=False,
             help=(
                 'Specify the test case(s) to execute by name only. '
+                'To view the available test case names, run the command "nvbandwidth -l" on the host. '
                 'If no specific test case is specified, all test cases will be executed by default.'
-                'Supported test cases are: ' + ', '.join(self._get_all_test_cases())
             ),
         )
 
@@ -263,9 +263,8 @@ class NvBandwidthBenchmark(MicroBenchmarkWithInvoke):
             self._result.add_result('abort', 1)
             return False
 
-    @staticmethod
-    def _get_all_test_cases():
-        command = 'nvbandwidth -l'
+    def _get_all_test_cases(self):
+        command = os.path.join(self._args.bin_dir, self._bin_name) + ' --list'
         test_case_pattern = re.compile(r'(\d+),\s+([\w_]+):')
 
         try:

--- a/tests/benchmarks/micro_benchmarks/test_nvbandwidth.py
+++ b/tests/benchmarks/micro_benchmarks/test_nvbandwidth.py
@@ -138,6 +138,9 @@ class TestNvBandwidthBenchmark(BenchmarkTestCase, unittest.TestCase):
 
         benchmark = benchmark_class(benchmark_name, parameters='')
 
+        # Call preprocess to initialize _args
+        assert benchmark._preprocess()
+
         # Mock subprocess.run for successful execution with valid output
         with unittest.mock.patch('subprocess.run') as mock_run:
             mock_run.return_value.returncode = 0


### PR DESCRIPTION
Root Cause:

1. '_get_all_test_cases()' was called in '_parser' while '_parser' was defined in the base class.
2.  in '_get_all_test_cases()', cmd path was not included.

Fix:

1. Remove '_get_all_test_cases()' from '_parser'.
2. Construct path for cmd.
