### PR TITLE
Lint: Enhancement of ignoring errors for import pkg_resources

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -3,3 +3,7 @@ exclude = build/
 ignore_missing_imports = True
 scripts_are_modules = True
 warn_return_any = True
+
+[mypy-pkg_resources]
+ignore_missing_imports = True
+

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -6,4 +6,3 @@ warn_return_any = True
 
 [mypy-pkg_resources]
 ignore_missing_imports = True
-


### PR DESCRIPTION
This enhancement addresses an issue in mypy where it may report missing pkg_resources even when ignore_missing_imports = True is set and the package is installed. Adding this configuration ensures that pkg_resources is properly skipped during type checking.