### PR TITLE
CI/CD - Update label in the ROCm image build

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -53,7 +53,7 @@ jobs:
           dockerfile: rocm6.2.x
           tags: superbench/main:rocm6.2
           platforms: linux/amd64
-          runner: [self-hosted, rocm]
+          runner: [self-hosted, linux/amd64, rocm]
           build_args: "NUM_MAKE_JOBS=16"
     steps:
       - name: Checkout

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -23,7 +23,6 @@ jobs:
       contents: read
       packages: write
     strategy:
-      fail-fast: false
       matrix:
         include:
         - name: cuda12.4 arm64
@@ -50,12 +49,6 @@ jobs:
           platforms: linux/amd64
           runner: ubuntu-latest
           build_args: "NUM_MAKE_JOBS=8"
-        - name: rocm6.2
-          dockerfile: rocm6.2.x
-          tags: superbench/main:rocm6.2
-          platforms: linux/amd64
-          runner: [self-hosted, linux/amd64]
-          build_args: "NUM_MAKE_JOBS=16"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -23,6 +23,7 @@ jobs:
       contents: read
       packages: write
     strategy:
+      fail-fast: false
       matrix:
         include:
         - name: cuda12.4 arm64

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -25,17 +25,23 @@ jobs:
     strategy:
       matrix:
         include:
+        - name: cuda12.4 arm64
+          dockerfile: cuda12.4
+          tags: superbench/main:cuda12.4
+          platforms: linux/arm64
+          runner: [self-hosted, linux/arm64]
+          build_args: "NUM_MAKE_JOBS=8"
         - name: cuda12.4
           dockerfile: cuda12.4
           tags: superbench/main:cuda12.4
-          platforms: linux/amd64 # TODO: linux/arm64
-          runner: [self-hosted]
+          platforms: linux/amd64
+          runner: [self-hosted, linux/amd64]
           build_args: "NUM_MAKE_JOBS=16"
         - name: cuda12.2
           dockerfile: cuda12.2
           tags: superbench/main:cuda12.2
           platforms: linux/amd64
-          runner: [self-hosted]
+          runner: [self-hosted, linux/amd64]
           build_args: "NUM_MAKE_JOBS=16"
         - name: cuda11.1.1
           dockerfile: cuda11.1.1
@@ -47,7 +53,7 @@ jobs:
           dockerfile: rocm6.2.x
           tags: superbench/main:rocm6.2
           platforms: linux/amd64
-          runner: [self-hosted]
+          runner: [self-hosted, linux/amd64]
           build_args: "NUM_MAKE_JOBS=16"
     steps:
       - name: Checkout

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -49,6 +49,12 @@ jobs:
           platforms: linux/amd64
           runner: ubuntu-latest
           build_args: "NUM_MAKE_JOBS=8"
+        - name: rocm6.2
+          dockerfile: rocm6.2.x
+          tags: superbench/main:rocm6.2
+          platforms: linux/amd64
+          runner: [self-hosted, rocm]
+          build_args: "NUM_MAKE_JOBS=16"
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Due to the matrix strategy’s default "fail-fast" setting. In GitHub Actions, when running a job with a matrix, the individual configurations run in parallel. By default, if one matrix job (for example, the one labeled "rocm6_2_rocm6_2_x_superbe") fails, the remaining parallel jobs are canceled automatically.

In our current build image pipeline, the arm64 build job always are canceled by the rocm build job. So, using a non-existent label in the job config to prevent rocm build job from scheduling for a temporary solution.
