### PR TITLE
Introduce --memPoolSize to trtexec

### DIFF
--- a/superbench/benchmarks/micro_benchmarks/tensorrt_inference_performance.py
+++ b/superbench/benchmarks/micro_benchmarks/tensorrt_inference_performance.py
@@ -104,7 +104,7 @@ class TensorRTInferenceBenchmark(MicroBenchmarkWithInvoke):
                 # build options
                 '--explicitBatch',
                 f'--optShapes=input:{input_shape}',
-                '--workspace=8192',
+                '–-memPoolSize=8G',
                 None if self._args.precision == 'fp32' else f'--{self._args.precision}',
                 # inference options
                 f'--iterations={self._args.iterations}',


### PR DESCRIPTION
**Description**
trtexec has a new parameter --memPoolSize, which was introduced as a substitute for --workspace (trtexec with workspace says that the parameters is DEPRECATED).
Link to official nvidia docs: [trtexec](https://docs.nvidia.com/deeplearning/tensorrt/latest/reference/command-line-programs.html)

