### PR TITLE
Feat/py2503 build

### DIFF
--- a/dockerfile/cuda12.8.dockerfile
+++ b/dockerfile/cuda12.8.dockerfile
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/pytorch:25.02-py3
+FROM nvcr.io/nvidia/pytorch:25.03-py3
 
 # OS:
 #   - Ubuntu: 24.04
@@ -164,7 +164,7 @@ ADD third_party third_party
 RUN make -C third_party cuda_with_msccl
 
 ADD . .
-RUN python3 -m pip install --upgrade setuptools==70.3.0 && \
+RUN python3 -m pip install --upgrade setuptools==75.8.2 && \
     python3 -m pip install --no-cache-dir .[nvworker] && \
     make cppbuild && \
     make postinstall && \

--- a/dockerfile/cuda12.8.dockerfile
+++ b/dockerfile/cuda12.8.dockerfile
@@ -5,9 +5,9 @@ FROM nvcr.io/nvidia/pytorch:25.03-py3
 #   - OpenMPI: 4.1.7+
 #   - Docker Client: 20.10.8
 # NVIDIA:
-#   - CUDA: 12.8.0.38
-#   - cuDNN: 9.7.1.26
-#   - cuBLAS: 12.8.3.14
+#   - CUDA: 12.8.1.012
+#   - cuDNN: 9.8.0.87
+#   - cuBLAS: 12.8.4.1
 #   - NCCL: v2.25.1
 #   - TransformerEngine 2.0
 # Mellanox:

--- a/setup.py
+++ b/setup.py
@@ -224,7 +224,7 @@ setup(
                 'yapf==0.31.0',
             ],
             'torch': [
-                ''safetensors<=0.5.3',
+                'safetensors<=0.5.3',
                 'tokenizers<=0.20.3',
                 'torch>=1.7.0a0',
                 'torchvision>=0.8.0a0',

--- a/setup.py
+++ b/setup.py
@@ -183,7 +183,7 @@ setup(
         'openpyxl>=3.0.7',
         'packaging>=21.0',
         'pandas>=1.1.5',
-        'protobuf<=3.20.3',
+        'protobuf<=4.24.4',
         'pssh @ git+https://github.com/lilydjwg/pssh.git@v2.3.4',
         'pyyaml>=5.3',
         'requests>=2.27.1',
@@ -224,7 +224,7 @@ setup(
                 'yapf==0.31.0',
             ],
             'torch': [
-                'safetensors==0.4.5',
+                ''safetensors<=0.5.3',
                 'tokenizers<=0.20.3',
                 'torch>=1.7.0a0',
                 'torchvision>=0.8.0a0',

--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -38,12 +38,12 @@ sb_micro_path:
 	mkdir -p $(SB_MICRO_PATH)/lib
 
 # Build cutlass.
-# for cuda 12.8 and later Build from commit 389e493 (3.8 release commit) for blackwell support
+# for cuda 12.8 and later Build from commit v3.9 (3.9 release commit) for blackwell support
 cuda_cutlass:
 ifeq ($(shell echo $(CUDA_VER)">=12.8" | bc -l), 1)
-	$(eval ARCHS := "75;80;86;89;90a;100;100a")
+	$(eval ARCHS := "90;90a;100;100a")
 	if [ -d cutlass ]; then rm -rf cutlass; fi
-	git clone --single-branch --branch main https://github.com/NVIDIA/cutlass.git && cd cutlass && git checkout 389e493
+	git clone --branch v3.9.1 --depth 1 https://github.com/NVIDIA/cutlass.git && cd cutlass
 else ifeq ($(shell echo $(CUDA_VER)">=11.8" | bc -l), 1)
 	$(eval ARCHS := "70;75;80;86;89;90")
 else


### PR DESCRIPTION
- Updated to use the latest pytorch ngc container 25.03 as it has latest cublas 12.8.4 . 
- regressions with cublas spotted from 25.02 version: 12.8.3
- added cutlas arch as they ignore the 
- use recent cutlass release v3.9.1
- Condense cutlass build to 90;90a;100;100a from 12.8 docker images to reduce build time.