### PR TITLE
Benchmarks - Add FP4 GEMM FLOPS support for cublaslt_gemm benchmark

### DIFF
--- a/superbench/benchmarks/micro_benchmarks/cublaslt_function.py
+++ b/superbench/benchmarks/micro_benchmarks/cublaslt_function.py
@@ -22,7 +22,7 @@ class CublasLtBenchmark(BlasLtBaseBenchmark):
         super().__init__(name, parameters)
 
         self._bin_name = 'cublaslt_gemm'
-        self._in_types = ['fp64', 'fp32', 'fp16', 'bf16', 'fp8e4m3', 'fp8e5m2', 'int8']
+        self._in_types = ['fp64', 'fp32', 'fp16', 'bf16', 'fp8e4m3', 'fp8e5m2', 'fp4e2m1', 'int8']
 
     def add_parser_arguments(self):
         """Add the specified arguments."""

--- a/superbench/benchmarks/micro_benchmarks/cublaslt_gemm/CMakeLists.txt
+++ b/superbench/benchmarks/micro_benchmarks/cublaslt_gemm/CMakeLists.txt
@@ -15,7 +15,7 @@ if(CUDAToolkit_FOUND AND NOT CUDAToolkit_VERSION VERSION_LESS 11.8)
     endif()
 
     add_library(cublaslt_utils SHARED cublaslt_utils.cc)
-    target_link_libraries(cublaslt_utils CUDA::cublas CUDA::cublasLt)
+    target_link_libraries(cublaslt_utils CUDA::cublas CUDA::cublasLt CUDA::cudart)
     set_target_properties(cublaslt_utils PROPERTIES LINK_FLAGS_RELEASE -s)
     install(TARGETS cublaslt_utils LIBRARY DESTINATION lib)
 

--- a/superbench/benchmarks/micro_benchmarks/cublaslt_gemm/cublaslt_gemm.cu
+++ b/superbench/benchmarks/micro_benchmarks/cublaslt_gemm/cublaslt_gemm.cu
@@ -7,6 +7,7 @@
 
 #include <cuda_fp16.h>
 #include <cuda_fp8.h>
+#include <cuda_fp4.h>
 
 #include "cublaslt_utils.h"
 
@@ -16,6 +17,7 @@ using fp16 = half;
 using bf16 = nv_bfloat16;
 using fp8e4m3 = __nv_fp8_e4m3;
 using fp8e5m2 = __nv_fp8_e5m2;
+using fp4e2m1 = __nv_fp4_e2m1;
 using int8 = int8_t;
 
 struct Args {
@@ -85,30 +87,35 @@ template <typename T> cudaDataType_t get_datatype() {
         return CUDA_R_8F_E4M3;
     if (std::is_same<T, fp8e5m2>::value)
         return CUDA_R_8F_E5M2;
+    if (std::is_same<T, fp4e2m1>::value)
+        return CUDA_R_4F_E2M1;
     if (std::is_same<T, int8>::value)
         return CUDA_R_8I;
     throw std::invalid_argument("Unknown type");
 }
 
-template <typename Ta, typename Tb, typename Tout>
+template <typename Ta, typename Tb, typename Tout, typename Tc>
 float timing_matmul_tn(size_t m, size_t n, size_t k, size_t batch, int warmup, int iter) {
     // init matrix
     Ta *matrix_a = nullptr;
     Tb *matrix_b = nullptr;
+    Tc *matrix_c = nullptr;
     Tout *matrix_out = nullptr;
     batch = std::max<size_t>(batch, 1);
     cudaMalloc(&matrix_a, m * k * batch * sizeof(Ta));
     cudaMalloc(&matrix_b, k * n * batch * sizeof(Tb));
+    cudaMalloc(&matrix_c, m * n * batch * sizeof(Tc));
     cudaMalloc(&matrix_out, m * n * batch * sizeof(Tout));
 
     init_matrix<Ta><<<216, 1024>>>(matrix_a, 1.f, m * k * batch);
     init_matrix<Tb><<<216, 1024>>>(matrix_b, 2.f, k * n * batch);
+    init_matrix<Tc><<<216, 1024>>>(matrix_c, 3.f, m * n * batch);
 
     // init gemm
-    size_t lda = k, ldb = k, ldd = m;
+    size_t lda = k, ldb = k, ldc = m, ldd = m;
     std::unique_ptr<cublasLtGemm> gemm = std::make_unique<cublasLtGemm>();
     gemm->Init();
-    gemm->Setup(m, n, k, batch, lda, ldb, ldd, get_datatype<Ta>(), get_datatype<Tb>(), get_datatype<Tout>(),
+    gemm->Setup(m, n, k, batch, lda, ldb, ldc, ldd, get_datatype<Ta>(), get_datatype<Tb>(), get_datatype<Tc>(), get_datatype<Tout>(),
                 CUBLAS_OP_T, CUBLAS_OP_N, CUBLASLT_EPILOGUE_DEFAULT);
 
     void *workspace = nullptr;
@@ -142,8 +149,8 @@ float timing_matmul_tn(size_t m, size_t n, size_t k, size_t batch, int warmup, i
     return (time * 1e3 / iter);
 }
 
-template <typename Ta, typename Tb = Ta, typename Tout = Ta> void run(Args *args) {
-    float time_us = timing_matmul_tn<Ta, Tb, Tout>(args->m, args->n, args->k, args->batch, args->warmup, args->iter);
+template <typename Ta, typename Tb = Ta, typename Tout = Ta, typename Tc = Tout> void run(Args *args) {
+    float time_us = timing_matmul_tn<Ta, Tb, Tout, Tc>(args->m, args->n, args->k, args->batch, args->warmup, args->iter);
     // m n k batch time_us tflops
     printf("%d\t%d\t%d\t%d\t%f\t%f\n", args->m, args->n, args->k, args->batch, time_us,
            float(args->m) * float(args->n) * float(2 * args->k - 1) / 1e6 / time_us * std::max(args->batch, 1));
@@ -165,6 +172,8 @@ int main(int argc, char **argv) {
         run<fp8e4m3, fp8e4m3, fp16>(&args);
     else if (args.in_type == "fp8e5m2")
         run<fp8e5m2, fp8e4m3, fp16>(&args);
+    else if (args.in_type == "fp4e2m1")
+        run<fp4e2m1, fp4e2m1, fp4e2m1, fp16>(&args);
     else if (args.in_type == "int8")
         run<int8>(&args);
     else

--- a/superbench/benchmarks/micro_benchmarks/cublaslt_gemm/cublaslt_utils.cc
+++ b/superbench/benchmarks/micro_benchmarks/cublaslt_gemm/cublaslt_utils.cc
@@ -14,21 +14,19 @@ void cublasLtGemm::Init() {
     preference_.reset(preference);
 }
 
-void cublasLtGemm::Setup(int m, int n, int k, int batch, int lda, int ldb, int ldd, cudaDataType_t a_type,
-                         cudaDataType_t b_type, cudaDataType_t d_type, cublasOperation_t transa,
+void cublasLtGemm::Setup(int m, int n, int k, int batch, int lda, int ldb, int ldc, int ldd, cudaDataType_t a_type,
+                         cudaDataType_t b_type, cudaDataType_t c_type, cudaDataType_t d_type, cublasOperation_t transa,
                          cublasOperation_t transb, cublasLtEpilogue_t epilogue,
                          void *a_scale_inverse, /* only need to be set for fp8 */
                          void *b_scale_inverse  /* only need to be set for fp8 */
 ) {
     cublasLtMatrixLayout_t a_desc = nullptr, b_desc = nullptr, c_desc = nullptr, d_desc = nullptr;
-    // force c_type
-    cudaDataType_t c_type = d_type;
     // Create matrix descriptors.
     CUBLAS_CHECK(
         cublasLtMatrixLayoutCreate(&a_desc, a_type, transa == CUBLAS_OP_N ? m : k, transa == CUBLAS_OP_N ? k : m, lda));
     CUBLAS_CHECK(
         cublasLtMatrixLayoutCreate(&b_desc, b_type, transb == CUBLAS_OP_N ? k : n, transb == CUBLAS_OP_N ? n : k, ldb));
-    CUBLAS_CHECK(cublasLtMatrixLayoutCreate(&c_desc, c_type, m, n, ldd));
+    CUBLAS_CHECK(cublasLtMatrixLayoutCreate(&c_desc, c_type, m, n, ldc));
     CUBLAS_CHECK(cublasLtMatrixLayoutCreate(&d_desc, d_type, m, n, ldd));
 
     // strided batch gemm
@@ -60,6 +58,8 @@ void cublasLtGemm::Setup(int m, int n, int k, int batch, int lda, int ldb, int l
     cublasComputeType_t gemm_compute_type = CUBLAS_COMPUTE_32F_FAST_TF32;
     if (a_type == CUDA_R_8F_E5M2 || b_type == CUDA_R_8F_E5M2 || a_type == CUDA_R_8F_E4M3 || b_type == CUDA_R_8F_E4M3)
         gemm_compute_type = CUBLAS_COMPUTE_32F;
+    if (a_type == CUDA_R_4F_E2M1 || b_type == CUDA_R_4F_E2M1)
+        gemm_compute_type = CUBLAS_COMPUTE_32F;
     if (a_type == CUDA_R_64F || b_type == CUDA_R_64F)
         gemm_compute_type = CUBLAS_COMPUTE_64F;
     if (a_type == CUDA_R_8I)
@@ -88,6 +88,36 @@ void cublasLtGemm::Setup(int m, int n, int k, int batch, int lda, int ldb, int l
     }
     CUBLAS_CHECK(
         cublasLtMatmulDescSetAttribute(op_desc_.get(), CUBLASLT_MATMUL_DESC_EPILOGUE, &epilogue, sizeof(epilogue)));
+
+    if (a_type == CUDA_R_4F_E2M1 || b_type == CUDA_R_4F_E2M1) {
+        // Allocate and copy device scale values
+        float a_scale = 1.0f, b_scale = 1.0f, d_scale = 1.0f, d_out_scale = 1.0f;
+        void *AscaleDev, *BscaleDev, *DscaleDev, *DOutscaleDev;
+        cudaMalloc(&AscaleDev, sizeof(float));
+        cudaMalloc(&BscaleDev, sizeof(float));
+        cudaMalloc(&DscaleDev, sizeof(float));
+        cudaMalloc(&DOutscaleDev, sizeof(float));
+        cudaMemcpy(AscaleDev, &a_scale, sizeof(float), cudaMemcpyHostToDevice);
+        cudaMemcpy(BscaleDev, &b_scale, sizeof(float), cudaMemcpyHostToDevice);
+        cudaMemcpy(DscaleDev, &d_scale, sizeof(float), cudaMemcpyHostToDevice);
+        cudaMemcpy(DOutscaleDev, &d_out_scale, sizeof(float), cudaMemcpyHostToDevice);
+
+        // Set scale modes
+        cublasLtMatmulMatrixScale_t AScaleMode = CUBLASLT_MATMUL_MATRIX_SCALE_VEC16_UE4M3;
+        cublasLtMatmulMatrixScale_t BScaleMode = CUBLASLT_MATMUL_MATRIX_SCALE_VEC16_UE4M3;
+        cublasLtMatmulMatrixScale_t DScaleMode = CUBLASLT_MATMUL_MATRIX_SCALE_SCALAR_32F;
+        cublasLtMatmulMatrixScale_t DOutScaleMode = CUBLASLT_MATMUL_MATRIX_SCALE_VEC16_UE4M3;
+        CUBLAS_CHECK(cublasLtMatmulDescSetAttribute(op_desc_.get(), CUBLASLT_MATMUL_DESC_A_SCALE_MODE, &AScaleMode, sizeof(AScaleMode)));
+        CUBLAS_CHECK(cublasLtMatmulDescSetAttribute(op_desc_.get(), CUBLASLT_MATMUL_DESC_B_SCALE_MODE, &BScaleMode, sizeof(BScaleMode)));
+        CUBLAS_CHECK(cublasLtMatmulDescSetAttribute(op_desc_.get(), CUBLASLT_MATMUL_DESC_D_SCALE_MODE, &DScaleMode, sizeof(DScaleMode)));
+        CUBLAS_CHECK(cublasLtMatmulDescSetAttribute(op_desc_.get(), CUBLASLT_MATMUL_DESC_D_OUT_SCALE_MODE, &DOutScaleMode, sizeof(DOutScaleMode)));
+
+        // Use device scale pointer attributes
+        CUBLAS_CHECK(cublasLtMatmulDescSetAttribute(op_desc_.get(), CUBLASLT_MATMUL_DESC_A_SCALE_POINTER, &AscaleDev, sizeof(void*)));
+        CUBLAS_CHECK(cublasLtMatmulDescSetAttribute(op_desc_.get(), CUBLASLT_MATMUL_DESC_B_SCALE_POINTER, &BscaleDev, sizeof(void*)));
+        CUBLAS_CHECK(cublasLtMatmulDescSetAttribute(op_desc_.get(), CUBLASLT_MATMUL_DESC_D_SCALE_POINTER, &DscaleDev, sizeof(void*)));
+        CUBLAS_CHECK(cublasLtMatmulDescSetAttribute(op_desc_.get(), CUBLASLT_MATMUL_DESC_D_OUT_SCALE_POINTER, &DOutscaleDev, sizeof(void*)));
+    }
 }
 
 size_t cublasLtGemm::GetAlgorithm(int max_algorithm_count, size_t max_workspace_size) {

--- a/superbench/benchmarks/micro_benchmarks/cublaslt_gemm/cublaslt_utils.h
+++ b/superbench/benchmarks/micro_benchmarks/cublaslt_gemm/cublaslt_utils.h
@@ -45,8 +45,8 @@ class cublasLtGemm {
 
     void Init();
 
-    void Setup(int m, int n, int k, int batch, int lda, int ldb, int ldd, cudaDataType_t a_type, cudaDataType_t b_type,
-               cudaDataType_t d_type, cublasOperation_t transa, cublasOperation_t transb, cublasLtEpilogue_t epilogue,
+    void Setup(int m, int n, int k, int batch, int lda, int ldb, int ldc, int ldd, cudaDataType_t a_type, cudaDataType_t b_type,
+               cudaDataType_t c_type, cudaDataType_t d_type, cublasOperation_t transa, cublasOperation_t transb, cublasLtEpilogue_t epilogue,
                void *a_scale_inverse = nullptr, void *b_scale_inverse = nullptr);
 
     size_t GetAlgorithm(int max_algorithm_count, size_t max_workspace_size);


### PR DESCRIPTION
**Description**
Add FP4 precision support for cublaslt_gemm benchmark.

**Major Revision**
- Add new type `fp4e2m1` and `__nv_fp4_e2m1`.
- For FP4 matmul, precision of MatrixC (add) should be FP16, precision of MatricD (output) should be FP4, otherwise, it will not work.
