### PR TITLE
Bugfix: deepseek benchmark names conflict

### DIFF
--- a/superbench/benchmarks/model_benchmarks/megatron_gpt3.py
+++ b/superbench/benchmarks/model_benchmarks/megatron_gpt3.py
@@ -749,7 +749,7 @@ BenchmarkRegistry.register_benchmark(
     'megatron-deepseek-v2', MegatronGPT, parameters='--model=deepseek', platform=Platform.ROCM
 )
 BenchmarkRegistry.register_benchmark(
-    'megatron-deepseek-v2',
+    'megatron-deepseek-v2-lite',
     MegatronGPT,
     parameters=(
         '--model=deepseek '


### PR DESCRIPTION
Summary
Deepseek currently registers two benchmarks using the same identifier, causing a naming conflict.

Change
Rename each benchmark so that both have unique, descriptive names.