### PR TITLE
Docs - Upgrade version and release note

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 __SuperBench__ is a validation and profiling tool for AI infrastructure.
 
-📢 [v0.11.0](https://github.com/microsoft/superbenchmark/releases/tag/v0.11.0) has been released!
+📢 [v0.12.0](https://github.com/microsoft/superbenchmark/releases/tag/v0.12.0) has been released!
 
 ## _Check [aka.ms/superbench](https://aka.ms/superbench) for more details._
 

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -61,7 +61,7 @@ You can clone the source from GitHub and build it.
 :::note Note
 You should checkout corresponding tag to use release version, for example,
 
-`git clone -b v0.11.0 https://github.com/microsoft/superbenchmark`
+`git clone -b v0.12.0 https://github.com/microsoft/superbenchmark`
 :::
 
 ```bash

--- a/docs/getting-started/run-superbench.md
+++ b/docs/getting-started/run-superbench.md
@@ -27,7 +27,7 @@ sb deploy -f remote.ini --host-password [password]
 :::note Note
 You should deploy corresponding Docker image to use release version, for example,
 
-`sb deploy -f local.ini -i superbench/superbench:v0.11.0-cuda12.4`
+`sb deploy -f local.ini -i superbench/superbench:v0.12.0-cuda12.9`
 
 You should note that version of git repo only determines version of sb CLI, and not the sb container. You should define the container version even if you specified a release version for the git clone.
 

--- a/docs/superbench-config.mdx
+++ b/docs/superbench-config.mdx
@@ -70,7 +70,7 @@ superbench:
 <TabItem value='example'>
 
 ```yaml
-version: v0.11
+version: v0.12
 superbench:
   enable: benchmark_1
   monitor:

--- a/docs/user-tutorial/container-images.mdx
+++ b/docs/user-tutorial/container-images.mdx
@@ -28,31 +28,39 @@ available tags are listed below for all stable versions.
 }>
 <TabItem value='cuda'>
 
-| Tag                | Description                         |
-|--------------------|-------------------------------------|
-| v0.11.0-cuda12.4   | SuperBench v0.11.0 with CUDA 12.4   |
-| v0.11.0-cuda12.2   | SuperBench v0.11.0 with CUDA 12.2   |
-| v0.11.0-cuda11.1.1 | SuperBench v0.11.0 with CUDA 11.1.1 |
-| v0.10.0-cuda12.2   | SuperBench v0.10.0 with CUDA 12.2   |
-| v0.10.0-cuda11.1.1 | SuperBench v0.10.0 with CUDA 11.1.1 |
-| v0.9.0-cuda12.1    | SuperBench v0.9.0 with CUDA 12.1    |
-| v0.9.0-cuda11.1.1  | SuperBench v0.9.0 with CUDA 11.1.1  |
-| v0.8.0-cuda12.1    | SuperBench v0.8.0 with CUDA 12.1    |
-| v0.8.0-cuda11.1.1  | SuperBench v0.8.0 with CUDA 11.1.1  |
-| v0.7.0-cuda11.8    | SuperBench v0.7.0 with CUDA 11.8    |
-| v0.7.0-cuda11.1.1  | SuperBench v0.7.0 with CUDA 11.1.1  |
-| v0.6.0-cuda11.1.1  | SuperBench v0.6.0 with CUDA 11.1.1  |
-| v0.5.0-cuda11.1.1  | SuperBench v0.5.0 with CUDA 11.1.1  |
-| v0.4.0-cuda11.1.1  | SuperBench v0.4.0 with CUDA 11.1.1  |
-| v0.3.0-cuda11.1.1  | SuperBench v0.3.0 with CUDA 11.1.1  |
-| v0.2.1-cuda11.1.1  | SuperBench v0.2.1 with CUDA 11.1.1  |
-| v0.2.0-cuda11.1.1  | SuperBench v0.2.0 with CUDA 11.1.1  |
+| Tag                    | Description                             |
+|------------------------|-----------------------------------------|
+| v0.12.0-cuda12.4-arm64 | SuperBench v0.12.0 with CUDA 12.9 ARM64 |
+| v0.12.0-cuda12.9-amd64 | SuperBench v0.12.0 with CUDA 12.9 AMD64 |
+| v0.12.0-cuda12.8-arm64 | SuperBench v0.12.0 with CUDA 12.8 ARM64 |
+| v0.12.0-cuda12.8-amd64 | SuperBench v0.12.0 with CUDA 12.8 AMD64 |
+| v0.12.0-cuda12.4       | SuperBench v0.12.0 with CUDA 12.4       |
+| v0.12.0-cuda12.2       | SuperBench v0.12.0 with CUDA 12.2       |
+| v0.12.0-cuda11.1.1     | SuperBench v0.12.0 with CUDA 11.1.1     |
+| v0.11.0-cuda12.4       | SuperBench v0.11.0 with CUDA 12.4       |
+| v0.11.0-cuda12.2       | SuperBench v0.11.0 with CUDA 12.2       |
+| v0.11.0-cuda11.1.1     | SuperBench v0.11.0 with CUDA 11.1.1     |
+| v0.10.0-cuda12.2       | SuperBench v0.10.0 with CUDA 12.2       |
+| v0.10.0-cuda11.1.1     | SuperBench v0.10.0 with CUDA 11.1.1     |
+| v0.9.0-cuda12.1        | SuperBench v0.9.0 with CUDA 12.1        |
+| v0.9.0-cuda11.1.1      | SuperBench v0.9.0 with CUDA 11.1.1      |
+| v0.8.0-cuda12.1        | SuperBench v0.8.0 with CUDA 12.1        |
+| v0.8.0-cuda11.1.1      | SuperBench v0.8.0 with CUDA 11.1.1      |
+| v0.7.0-cuda11.8        | SuperBench v0.7.0 with CUDA 11.8        |
+| v0.7.0-cuda11.1.1      | SuperBench v0.7.0 with CUDA 11.1.1      |
+| v0.6.0-cuda11.1.1      | SuperBench v0.6.0 with CUDA 11.1.1      |
+| v0.5.0-cuda11.1.1      | SuperBench v0.5.0 with CUDA 11.1.1      |
+| v0.4.0-cuda11.1.1      | SuperBench v0.4.0 with CUDA 11.1.1      |
+| v0.3.0-cuda11.1.1      | SuperBench v0.3.0 with CUDA 11.1.1      |
+| v0.2.1-cuda11.1.1      | SuperBench v0.2.1 with CUDA 11.1.1      |
+| v0.2.0-cuda11.1.1      | SuperBench v0.2.0 with CUDA 11.1.1      |
 
 </TabItem>
 <TabItem value='rocm'>
 
 | Tag                           | Description                                      |
 |-------------------------------|--------------------------------------------------|
+| v0.12.0-rocm6.2               | SuperBench v0.12.0 with ROCm 6.2                 |
 | v0.11.0-rocm6.2               | SuperBench v0.11.0 with ROCm 6.2                 |
 | v0.11.0-rocm6.0               | SuperBench v0.11.0 with ROCm 6.0                 |
 | v0.10.0-rocm6.0               | SuperBench v0.10.0 with ROCm 6.0                 |

--- a/docs/user-tutorial/container-images.mdx
+++ b/docs/user-tutorial/container-images.mdx
@@ -28,32 +28,30 @@ available tags are listed below for all stable versions.
 }>
 <TabItem value='cuda'>
 
-| Tag                    | Description                             |
-|------------------------|-----------------------------------------|
-| v0.12.0-cuda12.4-arm64 | SuperBench v0.12.0 with CUDA 12.9 ARM64 |
-| v0.12.0-cuda12.9-amd64 | SuperBench v0.12.0 with CUDA 12.9 AMD64 |
-| v0.12.0-cuda12.8-arm64 | SuperBench v0.12.0 with CUDA 12.8 ARM64 |
-| v0.12.0-cuda12.8-amd64 | SuperBench v0.12.0 with CUDA 12.8 AMD64 |
-| v0.12.0-cuda12.4       | SuperBench v0.12.0 with CUDA 12.4       |
-| v0.12.0-cuda12.2       | SuperBench v0.12.0 with CUDA 12.2       |
-| v0.12.0-cuda11.1.1     | SuperBench v0.12.0 with CUDA 11.1.1     |
-| v0.11.0-cuda12.4       | SuperBench v0.11.0 with CUDA 12.4       |
-| v0.11.0-cuda12.2       | SuperBench v0.11.0 with CUDA 12.2       |
-| v0.11.0-cuda11.1.1     | SuperBench v0.11.0 with CUDA 11.1.1     |
-| v0.10.0-cuda12.2       | SuperBench v0.10.0 with CUDA 12.2       |
-| v0.10.0-cuda11.1.1     | SuperBench v0.10.0 with CUDA 11.1.1     |
-| v0.9.0-cuda12.1        | SuperBench v0.9.0 with CUDA 12.1        |
-| v0.9.0-cuda11.1.1      | SuperBench v0.9.0 with CUDA 11.1.1      |
-| v0.8.0-cuda12.1        | SuperBench v0.8.0 with CUDA 12.1        |
-| v0.8.0-cuda11.1.1      | SuperBench v0.8.0 with CUDA 11.1.1      |
-| v0.7.0-cuda11.8        | SuperBench v0.7.0 with CUDA 11.8        |
-| v0.7.0-cuda11.1.1      | SuperBench v0.7.0 with CUDA 11.1.1      |
-| v0.6.0-cuda11.1.1      | SuperBench v0.6.0 with CUDA 11.1.1      |
-| v0.5.0-cuda11.1.1      | SuperBench v0.5.0 with CUDA 11.1.1      |
-| v0.4.0-cuda11.1.1      | SuperBench v0.4.0 with CUDA 11.1.1      |
-| v0.3.0-cuda11.1.1      | SuperBench v0.3.0 with CUDA 11.1.1      |
-| v0.2.1-cuda11.1.1      | SuperBench v0.2.1 with CUDA 11.1.1      |
-| v0.2.0-cuda11.1.1      | SuperBench v0.2.0 with CUDA 11.1.1      |
+| Tag                | Description                         |
+|--------------------|-------------------------------------|
+| v0.12.0-cuda12.9   | SuperBench v0.12.0 with CUDA 12.9   |
+| v0.12.0-cuda12.8   | SuperBench v0.12.0 with CUDA 12.8   |
+| v0.12.0-cuda12.4   | SuperBench v0.12.0 with CUDA 12.4   |
+| v0.12.0-cuda12.2   | SuperBench v0.12.0 with CUDA 12.2   |
+| v0.12.0-cuda11.1.1 | SuperBench v0.12.0 with CUDA 11.1.1 |
+| v0.11.0-cuda12.4   | SuperBench v0.11.0 with CUDA 12.4   |
+| v0.11.0-cuda12.2   | SuperBench v0.11.0 with CUDA 12.2   |
+| v0.11.0-cuda11.1.1 | SuperBench v0.11.0 with CUDA 11.1.1 |
+| v0.10.0-cuda12.2   | SuperBench v0.10.0 with CUDA 12.2   |
+| v0.10.0-cuda11.1.1 | SuperBench v0.10.0 with CUDA 11.1.1 |
+| v0.9.0-cuda12.1    | SuperBench v0.9.0 with CUDA 12.1    |
+| v0.9.0-cuda11.1.1  | SuperBench v0.9.0 with CUDA 11.1.1  |
+| v0.8.0-cuda12.1    | SuperBench v0.8.0 with CUDA 12.1    |
+| v0.8.0-cuda11.1.1  | SuperBench v0.8.0 with CUDA 11.1.1  |
+| v0.7.0-cuda11.8    | SuperBench v0.7.0 with CUDA 11.8    |
+| v0.7.0-cuda11.1.1  | SuperBench v0.7.0 with CUDA 11.1.1  |
+| v0.6.0-cuda11.1.1  | SuperBench v0.6.0 with CUDA 11.1.1  |
+| v0.5.0-cuda11.1.1  | SuperBench v0.5.0 with CUDA 11.1.1  |
+| v0.4.0-cuda11.1.1  | SuperBench v0.4.0 with CUDA 11.1.1  |
+| v0.3.0-cuda11.1.1  | SuperBench v0.3.0 with CUDA 11.1.1  |
+| v0.2.1-cuda11.1.1  | SuperBench v0.2.1 with CUDA 11.1.1  |
+| v0.2.0-cuda11.1.1  | SuperBench v0.2.0 with CUDA 11.1.1  |
 
 </TabItem>
 <TabItem value='rocm'>

--- a/docs/user-tutorial/container-images.mdx
+++ b/docs/user-tutorial/container-images.mdx
@@ -58,7 +58,6 @@ available tags are listed below for all stable versions.
 
 | Tag                           | Description                                      |
 |-------------------------------|--------------------------------------------------|
-| v0.12.0-rocm6.2               | SuperBench v0.12.0 with ROCm 6.2                 |
 | v0.11.0-rocm6.2               | SuperBench v0.11.0 with ROCm 6.2                 |
 | v0.11.0-rocm6.0               | SuperBench v0.11.0 with ROCm 6.0                 |
 | v0.10.0-rocm6.0               | SuperBench v0.10.0 with ROCm 6.0                 |

--- a/docs/user-tutorial/data-diagnosis.md
+++ b/docs/user-tutorial/data-diagnosis.md
@@ -65,7 +65,7 @@ superbench:
 example:
 ```yaml
 # SuperBench rules
-version: v0.11
+version: v0.12
 superbench:
   rules:
     failure-rule:

--- a/docs/user-tutorial/result-summary.md
+++ b/docs/user-tutorial/result-summary.md
@@ -58,7 +58,7 @@ superbench:
 
 ```yaml title="Example"
 # SuperBench rules
-version: v0.11
+version: v0.12
 superbench:
   rules:
     kernel_launch:

--- a/superbench/__init__.py
+++ b/superbench/__init__.py
@@ -6,5 +6,5 @@
 Provide hardware and software benchmarks for AI systems.
 """
 
-__version__ = '0.11.0'
+__version__ = '0.12.0'
 __author__ = 'Microsoft'

--- a/superbench/config/amd_mi100_hpe.yaml
+++ b/superbench/config/amd_mi100_hpe.yaml
@@ -3,7 +3,7 @@
 # Server:
 #   - Product: HPE Apollo 6500
 
-version: v0.11
+version: v0.12
 superbench:
   enable: null
   var:

--- a/superbench/config/amd_mi100_z53.yaml
+++ b/superbench/config/amd_mi100_z53.yaml
@@ -4,7 +4,7 @@
 #   - Product: G482-Z53
 #   - Link: https://www.gigabyte.cn/FileUpload/Global/MicroSite/553/G482-Z53.html
 
-version: v0.11
+version: v0.12
 superbench:
   enable: null
   var:

--- a/superbench/config/amd_mi300.yaml
+++ b/superbench/config/amd_mi300.yaml
@@ -1,5 +1,5 @@
 # SuperBench Config
-version: v0.11
+version: v0.12
 superbench:
   enable: null
   var:

--- a/superbench/config/azure/inference/standard_nc64as_t4_v3.yaml
+++ b/superbench/config/azure/inference/standard_nc64as_t4_v3.yaml
@@ -1,4 +1,4 @@
-version: v0.11
+version: v0.12
 superbench:
   enable: null
   monitor:

--- a/superbench/config/azure/inference/standard_nc96ads_a100_v4.yaml
+++ b/superbench/config/azure/inference/standard_nc96ads_a100_v4.yaml
@@ -1,4 +1,4 @@
-version: v0.11
+version: v0.12
 superbench:
   enable: null
   monitor:

--- a/superbench/config/azure/inference/standard_nv18ads_a10_v5.yaml
+++ b/superbench/config/azure/inference/standard_nv18ads_a10_v5.yaml
@@ -1,4 +1,4 @@
-version: v0.11
+version: v0.12
 superbench:
   enable: null
   monitor:

--- a/superbench/config/azure_ndmv4.yaml
+++ b/superbench/config/azure_ndmv4.yaml
@@ -3,7 +3,7 @@
 # Azure NDm A100 v4
 # reference: https://docs.microsoft.com/en-us/azure/virtual-machines/ndm-a100-v4-series
 
-version: v0.11
+version: v0.12
 superbench:
   enable: null
   monitor:

--- a/superbench/config/azure_ndv4.yaml
+++ b/superbench/config/azure_ndv4.yaml
@@ -1,5 +1,5 @@
 # SuperBench Config
-version: v0.11
+version: v0.12
 superbench:
   enable: null
   monitor:

--- a/superbench/config/azure_ndv5.yaml
+++ b/superbench/config/azure_ndv5.yaml
@@ -1,5 +1,5 @@
 # SuperBench Config
-version: v0.11
+version: v0.12
 superbench:
   enable:
   monitor:

--- a/superbench/config/default.yaml
+++ b/superbench/config/default.yaml
@@ -1,5 +1,5 @@
 # SuperBench Config
-version: v0.11
+version: v0.12
 superbench:
   enable: null
   monitor:

--- a/website/blog/2025-08-06-release-0-12.md
+++ b/website/blog/2025-08-06-release-0-12.md
@@ -1,0 +1,60 @@
+---
+slug: release-sb-v0.12
+title: Releasing SuperBench v0.12
+author: Guoshuai Zhao
+author_title: SuperBench Team
+author_url: https://github.com/guoshzhao
+author_image_url: https://github.com/guoshzhao.png
+tags: [superbench, announcement, release]
+---
+
+We are very happy to announce that **SuperBench 0.12.0 version** is officially released today!
+
+You can install and try superbench by following [Getting Started Tutorial](https://microsoft.github.io/superbenchmark/docs/getting-started/installation).
+
+## SuperBench 0.12.0 Release Notes
+
+### SuperBench Improvements
+
+- Update Image Build Pipeline.
+- Add support for arm64 build.
+- Upgrade dependency versions in pipeline.
+- Fix installation and lint issues.
+- Update Flake8 repo.
+- Init latest python support, eg python3.11 and python3.12.
+- Add image build on arm64 arch.
+- Enhancement of ignoring errors for import pkg_resources.
+- Update label in the ROCm image build.
+- Support cuda12.8 for Blackwell arch.
+- Support cuda12.9 for Blackwell arch.
+- Update OS of runner to the latest.
+- cuda arch flag for cublaslt.
+
+### Micro-benchmark Improvements
+
+- Bug Fix - Fix numa error on grace cpu in gpu-copy
+- Dependency - Bump onnxruntime-gpu version from 1.10.0 to 1.12.0
+- Benchmarks: micro benchmarks - add general CPU bandwidth and latency benchmark
+- Benchmarks: micro benchmarks - add nvbandwidth build and benchmark
+- Fix stderr message in gpu-copy benchmark
+- Add arch support for 10.0 in gemm-flops
+- Fix tensorrt-inference parsing
+- nvbandwidth benchmark need to handle N/A value
+- Avoid Unintended nvbandwidth Function Calls in All Benchmarks
+- Add GPU Stream Micro Benchmark
+- Cuda arch flag for cublaslt
+- Support autotuning in cublaslt gemm
+- Add FP4 GEMM FLOPS support for cublaslt_gemm benchmark
+- CPU Stream Benchmark Revise
+- Add cuda12.9 docker image
+- Add Grace CPU support for CPU Stream
+
+## Model-benchmark Improvements
+
+- Add LLaMA-2 Models
+- Fix typos in documentation and code files
+- Add Mixture of Experts Model
+- Add DeepSeek Inference Benchmark (AMD GPU)
+
+### Result Analysis
+- Enhance logging information for diagnosis rule op baseline errors.

--- a/website/blog/2025-08-06-release-0-12.md
+++ b/website/blog/2025-08-06-release-0-12.md
@@ -16,46 +16,46 @@ You can install and try SuperBench by following the [Getting Started Tutorial](h
 
 ### SuperBench Improvements
 
-- Improve image build pipeline
-- Add support for arm64 builds
-- Upgrade pipeline dependencies
-- Fix SuperBench installation and code lint issues
-- Update Flake8 repository
-- Add support for the latest Python versions
-- Enhance error handling for `pkg_resources` imports
-- Update ROCm image build labels
-- Add CUDA 12.8 and CUDA 12.9 support
-- Consolidate multi-architecture Docker images
-- Upgrade runner OS to latest version
+- Improve image build pipeline.
+- Add support for arm64 builds.
+- Upgrade pipeline dependencies.
+- Fix SuperBench installation and code lint issues.
+- Update Flake8 repository.
+- Add support for the latest Python versions.
+- Enhance error handling for `pkg_resources` imports.
+- Update ROCm image build labels.
+- Add CUDA 12.8 and CUDA 12.9 support.
+- Consolidate multi-architecture Docker images.
+- Upgrade runner OS to latest version.
 
 ### Micro-benchmark Improvements
 
-- Add general CPU bandwidth and latency benchmarks
-- Add nvbandwidth build process and benchmarks
-- Add architecture support for 10.0 in gemm-flops
-- Add GPU Stream micro benchmark
-- Add FP4 GEMM FLOPS support in `cublaslt_gemm` benchmark
-- Add Grace CPU support for CPU Stream benchmark
-- Revise CPU Stream benchmark
-- Fix NUMA error on Grace CPU in gpu-copy benchmark
-- Bump onnxruntime-gpu dependency from 1.10.0 to 1.12.0
-- Fix stderr message in gpu-copy benchmark
-- Fix TensorRT inference parsing
-- Handle N/A values in nvbandwidth benchmark
-- Avoid unintended nvbandwidth function calls in all benchmarks
-- Support CUDA arch flag and autotuning in `cublaslt` GEMM
+- Add general CPU bandwidth and latency benchmarks.
+- Add nvbandwidth build process and benchmarks.
+- Add architecture support for 10.0 in gemm-flops.
+- Add GPU Stream micro benchmark.
+- Add FP4 GEMM FLOPS support in `cublaslt_gemm` benchmark.
+- Add Grace CPU support for CPU Stream benchmark.
+- Revise CPU Stream benchmark.
+- Fix NUMA error on Grace CPU in gpu-copy benchmark.
+- Bump onnxruntime-gpu dependency from 1.10.0 to 1.12.0.
+- Fix stderr message in gpu-copy benchmark.
+- Fix TensorRT inference parsing.
+- Handle N/A values in nvbandwidth benchmark.
+- Avoid unintended nvbandwidth function calls in all benchmarks.
+- Support CUDA arch flag and autotuning in `cublaslt` GEMM.
 
 ## Model-benchmark Improvements
 
-- Add LLaMA-2 model benchmarks
-- Add Mixture of Experts model benchmarks
-- Add DeepSeek inference benchmark (AMD GPU)
-- Fix typos in documentation and code
+- Add LLaMA-2 model benchmarks.
+- Add Mixture of Experts model benchmarks.
+- Add DeepSeek inference benchmark (AMD GPU).
+- Fix typos in documentation and code.
 
 ### Result Analysis
 
-- Enhance logging for diagnosis rule baseline errors
+- Enhance logging for diagnosis rule baseline errors.
 
 ### Documentation Updates
 
-- Update CODEOWNERS file
+- Update CODEOWNERS file.

--- a/website/blog/2025-08-06-release-0-12.md
+++ b/website/blog/2025-08-06-release-0-12.md
@@ -10,51 +10,52 @@ tags: [superbench, announcement, release]
 
 We are very happy to announce that **SuperBench 0.12.0 version** is officially released today!
 
-You can install and try superbench by following [Getting Started Tutorial](https://microsoft.github.io/superbenchmark/docs/getting-started/installation).
+You can install and try SuperBench by following the [Getting Started Tutorial](https://microsoft.github.io/superbenchmark/docs/getting-started/installation).
 
 ## SuperBench 0.12.0 Release Notes
 
 ### SuperBench Improvements
 
-- Update Image Build Pipeline.
-- Add support for arm64 build.
-- Upgrade dependency versions in pipeline.
-- Fix installation and lint issues.
-- Update Flake8 repo.
-- Init latest python support, eg python3.11 and python3.12.
-- Add image build on arm64 arch.
-- Enhancement of ignoring errors for import pkg_resources.
-- Update label in the ROCm image build.
-- Support cuda12.8 for Blackwell arch.
-- Support cuda12.9 for Blackwell arch.
-- Update OS of runner to the latest.
-- cuda arch flag for cublaslt.
+- Improve image build pipeline
+- Add support for arm64 builds
+- Upgrade pipeline dependencies
+- Fix SuperBench installation and code lint issues
+- Update Flake8 repository
+- Add support for the latest Python versions
+- Enhance error handling for `pkg_resources` imports
+- Update ROCm image build labels
+- Add CUDA 12.8 and CUDA 12.9 support
+- Consolidate multi-architecture Docker images
+- Upgrade runner OS to latest version
 
 ### Micro-benchmark Improvements
 
-- Bug Fix - Fix numa error on grace cpu in gpu-copy
-- Dependency - Bump onnxruntime-gpu version from 1.10.0 to 1.12.0
-- Benchmarks: micro benchmarks - add general CPU bandwidth and latency benchmark
-- Benchmarks: micro benchmarks - add nvbandwidth build and benchmark
+- Add general CPU bandwidth and latency benchmarks
+- Add nvbandwidth build process and benchmarks
+- Add architecture support for 10.0 in gemm-flops
+- Add GPU Stream micro benchmark
+- Add FP4 GEMM FLOPS support in `cublaslt_gemm` benchmark
+- Add Grace CPU support for CPU Stream benchmark
+- Revise CPU Stream benchmark
+- Fix NUMA error on Grace CPU in gpu-copy benchmark
+- Bump onnxruntime-gpu dependency from 1.10.0 to 1.12.0
 - Fix stderr message in gpu-copy benchmark
-- Add arch support for 10.0 in gemm-flops
-- Fix tensorrt-inference parsing
-- nvbandwidth benchmark need to handle N/A value
-- Avoid Unintended nvbandwidth Function Calls in All Benchmarks
-- Add GPU Stream Micro Benchmark
-- Cuda arch flag for cublaslt
-- Support autotuning in cublaslt gemm
-- Add FP4 GEMM FLOPS support for cublaslt_gemm benchmark
-- CPU Stream Benchmark Revise
-- Add cuda12.9 docker image
-- Add Grace CPU support for CPU Stream
+- Fix TensorRT inference parsing
+- Handle N/A values in nvbandwidth benchmark
+- Avoid unintended nvbandwidth function calls in all benchmarks
+- Support CUDA arch flag and autotuning in `cublaslt` GEMM
 
 ## Model-benchmark Improvements
 
-- Add LLaMA-2 Models
-- Fix typos in documentation and code files
-- Add Mixture of Experts Model
-- Add DeepSeek Inference Benchmark (AMD GPU)
+- Add LLaMA-2 model benchmarks
+- Add Mixture of Experts model benchmarks
+- Add DeepSeek inference benchmark (AMD GPU)
+- Fix typos in documentation and code
 
 ### Result Analysis
-- Enhance logging information for diagnosis rule op baseline errors.
+
+- Enhance logging for diagnosis rule baseline errors
+
+### Documentation Updates
+
+- Update CODEOWNERS file

--- a/website/blog/2025-08-06-release-0-12.md
+++ b/website/blog/2025-08-06-release-0-12.md
@@ -16,6 +16,7 @@ You can install and try SuperBench by following the [Getting Started Tutorial](h
 
 ### SuperBench Improvements
 
+- Optimized cutlass build process for faster builds and smaller binaries.
 - Improve image build pipeline.
 - Add support for arm64 builds.
 - Upgrade pipeline dependencies.

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -101,7 +101,7 @@ module.exports = {
     announcementBar: {
       id: 'supportus',
       content:
-        '📢 <a href="https://microsoft.github.io/superbenchmark/blog/release-sb-v0.11">v0.11.0</a> has been released! ' +
+        '📢 <a href="https://microsoft.github.io/superbenchmark/blog/release-sb-v0.11">v0.12.0</a> has been released! ' +
         '⭐️ If you like SuperBench, give it a star on <a target="_blank" rel="noopener noreferrer" href="https://github.com/microsoft/superbenchmark">GitHub</a>! ⭐️',
     },
     algolia: {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "superbench-website",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superbench-website",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",


### PR DESCRIPTION
# Release v0.12.0

## Main Features & Improvements

### SuperBench Enhancements
- Optimized cutlass build process for faster builds and smaller binaries (#716)
- Updated image build pipeline (#659)
- Added support for arm64 builds (#660, #690)
- Upgraded pipeline dependencies (#671)
- Fixed installation and lint issues (#684)
- Updated Flake8 repository (#683)
- Added support for the latest Python versions (#687)
- Enhanced error handling for `pkg_resources` imports (#692)
- Updated ROCm image build labels (#693)
- Added CUDA 12.8 and CUDA12.9 support (#682, #716)
- Consolidated multi-architecture Docker images (#696)
- Updated runner OS to latest version (#702)

### Micro-benchmark Improvements
- Added general CPU bandwidth and latency benchmarks (#662)
- Added nvbandwidth build and benchmark (#665, #669)
- Added architecture support for 10.0 in gemm-flops (#680)
- Added GPU Stream micro benchmark (#697)
- Added FP4 GEMM FLOPS support in `cublaslt_gemm` benchmark (#711)
- Added Grace CPU support for CPU Stream benchmark (#719)
- Fixed NUMA error on Grace CPU in gpu-copy benchmark (#658)
- Bumped onnxruntime-gpu dependency from 1.10.0 to 1.12.0 (#663)
- Fixed stderr message in gpu-copy benchmark (#673)
- Fixed TensorRT inference parsing (#674)
- Handled N/A values in nvbandwidth benchmark (#675)
- Avoided unintended nvbandwidth function calls in all benchmarks (#685)
- Supported CUDA arch flag and autotuning in `cublaslt` GEMM (#701, #706)
- Revised CPU Stream benchmark (#712)

### Model Benchmark Improvements
- Added LLaMA-2 models (#668)
- Added Mixture of Experts model (#679)
- Added DeepSeek inference benchmark (AMD GPU) (#713)
- Fixed typos in documentation and code (#686)

### Documentation Updates
- Updated CODEOWNERS file (#670, #718)

### Result Analysis
- Enhanced logging for diagnosis rule baseline errors (#689)
