### PR TITLE
Aishwaryatonpe/deterministic training

### DIFF
--- a/examples/benchmarks/pytorch_bert_large.py
+++ b/examples/benchmarks/pytorch_bert_large.py
@@ -7,8 +7,17 @@ Commands to run:
   python3 examples/benchmarks/pytorch_bert_large.py (Single GPU)
   python3 -m torch.distributed.launch --use_env --nproc_per_node=8 examples/benchmarks/pytorch_bert_large.py \
       --distributed (Distributed)
-"""
 
+
+  Deterministic examples:
+  # Soft determinism:
+  python3 examples/benchmarks/pytorch_bert_large.py --deterministic --random_seed 42
+
+  # Strict determinism (requires cuBLAS env):
+  CUBLAS_WORKSPACE_CONFIG=:4096:8 python3 examples/benchmarks/pytorch_bert_large.py \
+  --deterministic --random_seed 42 --strict_determinism
+"""
+import os
 import argparse
 
 from superbench.benchmarks import Platform, Framework, BenchmarkRegistry
@@ -19,6 +28,12 @@ if __name__ == '__main__':
     parser.add_argument(
         '--distributed', action='store_true', default=False, help='Whether to enable distributed training.'
     )
+    parser.add_argument('--deterministic', action='store_true', default=False, help='Enable deterministic training.')
+    parser.add_argument('--random_seed', type=int, default=None, help='Fixed seed when using --deterministic.')
+    parser.add_argument(
+        '--strict_determinism', action='store_true', default=False,
+        help='Enable strict determinism checks (set SB_STRICT_DETERMINISM=1). Requires CUBLAS_WORKSPACE_CONFIG env.'
+    )
     args = parser.parse_args()
 
     # Specify the model name and benchmark parameters.
@@ -26,6 +41,15 @@ if __name__ == '__main__':
     parameters = '--batch_size 1 --duration 120 --seq_len 128 --precision float32 --run_count 2'
     if args.distributed:
         parameters += ' --distributed_impl ddp --distributed_backend nccl'
+
+    if args.deterministic:
+        parameters += ' --deterministic --precision float32'
+    if args.random_seed is not None:
+        parameters += f' --random_seed {args.random_seed}'
+
+    if args.strict_determinism:
+        os.environ['SB_STRICT_DETERMINISM'] = '1'
+        logger.info('Strict determinism enabled (SB_STRICT_DETERMINISM=1). Ensure CUBLAS_WORKSPACE_CONFIG is set.')
 
     # Create context for bert-large benchmark and run it for 120 * 2 seconds.
     context = BenchmarkRegistry.create_benchmark_context(

--- a/examples/benchmarks/pytorch_gpt2_large.py
+++ b/examples/benchmarks/pytorch_gpt2_large.py
@@ -7,9 +7,19 @@ Commands to run:
   python3 examples/benchmarks/pytorch_gpt2_large.py (Single GPU)
   python3 -m torch.distributed.launch --use_env --nproc_per_node=8 examples/benchmarks/pytorch_gpt2_large.py \
       --distributed (Distributed)
+
+
+  Deterministic examples:
+  # Soft determinism:
+  python3 examples/benchmarks/pytorch_gpt2_large.py --deterministic --random_seed 42
+
+  # Strict determinism (requires cuBLAS env):
+  CUBLAS_WORKSPACE_CONFIG=:4096:8 python3 examples/benchmarks/pytorch_gpt2_large.py \
+  --deterministic --random_seed 42 --strict_determinism
 """
 
 import argparse
+import os
 
 from superbench.benchmarks import Platform, Framework, BenchmarkRegistry
 from superbench.common.utils import logger
@@ -19,6 +29,12 @@ if __name__ == '__main__':
     parser.add_argument(
         '--distributed', action='store_true', default=False, help='Whether to enable distributed training.'
     )
+    parser.add_argument('--deterministic', action='store_true', default=False, help='Enable deterministic training.')
+    parser.add_argument('--random_seed', type=int, default=None, help='Fixed seed when using --deterministic.')
+    parser.add_argument(
+        '--strict_determinism', action='store_true', default=False,
+        help='Enable strict determinism checks (set SB_STRICT_DETERMINISM=1). Requires CUBLAS_WORKSPACE_CONFIG env.'
+    )
     args = parser.parse_args()
 
     # Specify the model name and benchmark parameters.
@@ -26,6 +42,14 @@ if __name__ == '__main__':
     parameters = '--batch_size 1 --duration 120 --seq_len 128 --precision float32 --run_count 2'
     if args.distributed:
         parameters += ' --distributed_impl ddp --distributed_backend nccl'
+    if args.deterministic:
+        parameters += ' --deterministic --precision float32'
+    if args.random_seed is not None:
+        parameters += f' --random_seed {args.random_seed}'
+
+    if args.strict_determinism:
+        os.environ['SB_STRICT_DETERMINISM'] = '1'
+        logger.info('Strict determinism enabled (SB_STRICT_DETERMINISM=1). Ensure CUBLAS_WORKSPACE_CONFIG is set.')
 
     # Create context for gpt2-large benchmark and run it for 120 * 2 seconds.
     context = BenchmarkRegistry.create_benchmark_context(

--- a/examples/benchmarks/pytorch_llama2.py
+++ b/examples/benchmarks/pytorch_llama2.py
@@ -4,12 +4,21 @@
 """Model benchmark example for Llama2-7b (32-layer, 4096-hidden, 32-heads, 7B parameters).
 
 Commands to run:
-  python3 examples/benchmarks/pytorch_llama2.py (Single GPU)
-  python3 -m torch.distributed.launch --use_env --nproc_per_node=8 examples/benchmarks/pytorch_llama2.py \
+  python3 examples/benchmarks/pytorch_lstm.py (Single GPU)
+  python3 -m torch.distributed.launch --use_env --nproc_per_node=8 examples/benchmarks/pytorch_lstm.py \
       --distributed (Distributed)
+
+  Deterministic examples:
+  # Soft determinism (numeric reproducibility target):
+  python3 examples/benchmarks/pytorch_llama2.py --deterministic --random_seed 42
+
+  # Strict determinism (exact reproducibility; requires cuBLAS env):
+  CUBLAS_WORKSPACE_CONFIG=:4096:8 python3 examples/benchmarks/pytorch_llama2.py \
+      --deterministic --random_seed 42 --strict_determinism
 """
 
 import argparse
+import os
 
 from superbench.benchmarks import Platform, Framework, BenchmarkRegistry
 from superbench.common.utils import logger
@@ -19,6 +28,12 @@ if __name__ == '__main__':
     parser.add_argument(
         '--distributed', action='store_true', default=False, help='Whether to enable distributed training.'
     )
+    parser.add_argument('--deterministic', action='store_true', default=False, help='Enable deterministic training.')
+    parser.add_argument('--random_seed', type=int, default=None, help='Fixed seed when using --deterministic.')
+    parser.add_argument(
+        '--strict_determinism', action='store_true', default=False,
+        help='Enable strict determinism checks (set SB_STRICT_DETERMINISM=1). Requires CUBLAS_WORKSPACE_CONFIG env.'
+    )
     args = parser.parse_args()
 
     # Specify the model name and benchmark parameters.
@@ -26,6 +41,15 @@ if __name__ == '__main__':
     parameters = '--batch_size 1 --duration 120 --seq_len 512 --precision float16'
     if args.distributed:
         parameters += ' --distributed_impl ddp --distributed_backend nccl'
+    if args.deterministic:
+        parameters += ' --deterministic --precision float32'
+    if args.random_seed is not None:
+        parameters += f' --random_seed {args.random_seed}'
+
+    if args.strict_determinism:
+        # Hint: CUBLAS_WORKSPACE_CONFIG must be set by the user before CUDA init for strict reproducibility.
+        os.environ['SB_STRICT_DETERMINISM'] = '1'
+        logger.info('Strict determinism enabled (SB_STRICT_DETERMINISM=1). Ensure CUBLAS_WORKSPACE_CONFIG is set.')
 
     # Create context for Llama2 benchmark and run it for 120 seconds.
     context = BenchmarkRegistry.create_benchmark_context(

--- a/examples/benchmarks/pytorch_lstm.py
+++ b/examples/benchmarks/pytorch_lstm.py
@@ -7,9 +7,18 @@ Commands to run:
   python3 examples/benchmarks/pytorch_lstm.py (Single GPU)
   python3 -m torch.distributed.launch --use_env --nproc_per_node=8 examples/benchmarks/pytorch_lstm.py \
       --distributed (Distributed)
+
+  Deterministic examples:
+  # Soft determinism:
+  python3 examples/benchmarks/pytorch_lstm.py --deterministic --random_seed 42
+
+  # Strict determinism (requires cuBLAS env):
+  CUBLAS_WORKSPACE_CONFIG=:4096:8 python3 examples/benchmarks/pytorch_lstm.py \
+  --deterministic --random_seed 42 --strict_determinism
 """
 
 import argparse
+import os
 
 from superbench.benchmarks import Platform, Framework, BenchmarkRegistry
 from superbench.common.utils import logger
@@ -19,6 +28,12 @@ if __name__ == '__main__':
     parser.add_argument(
         '--distributed', action='store_true', default=False, help='Whether to enable distributed training.'
     )
+    parser.add_argument('--deterministic', action='store_true', default=False, help='Enable deterministic training.')
+    parser.add_argument('--random_seed', type=int, default=None, help='Fixed seed when using --deterministic.')
+    parser.add_argument(
+        '--strict_determinism', action='store_true', default=False,
+        help='Enable strict determinism checks (set SB_STRICT_DETERMINISM=1). Requires CUBLAS_WORKSPACE_CONFIG env.'
+    )
     args = parser.parse_args()
 
     # Specify the model name and benchmark parameters.
@@ -26,6 +41,14 @@ if __name__ == '__main__':
     parameters = '--batch_size 1 --seq_len 256 --precision float32 --num_warmup 8 --num_steps 64 --run_count 2'
     if args.distributed:
         parameters += ' --distributed_impl ddp --distributed_backend nccl'
+    if args.deterministic:
+        parameters += ' --deterministic --precision float32'
+    if args.random_seed is not None:
+        parameters += f' --random_seed {args.random_seed}'
+
+    if args.strict_determinism:
+        os.environ['SB_STRICT_DETERMINISM'] = '1'
+        logger.info('Strict determinism enabled (SB_STRICT_DETERMINISM=1). Ensure CUBLAS_WORKSPACE_CONFIG is set.')
 
     # Create context for lstm benchmark and run it for 64 steps.
     context = BenchmarkRegistry.create_benchmark_context(

--- a/superbench/benchmarks/model_benchmarks/pytorch_bert.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_bert.py
@@ -237,11 +237,17 @@ class PytorchBERT(PytorchBase):
                         losses.append(float(loss.detach().item()))
                     except Exception:
                         pass
-                    # Periodic checksum logging when deterministic is enabled
+                    # Periodic lightweight fingerprints when deterministic is enabled (near-zero overhead)
                     if getattr(self._args, 'deterministic', False) and (curr_step % check_frequency == 0):
+                        # 1) Loss fingerprint
                         try:
-                            checksum = sum(p.detach().float().sum().item() for p in self._model.parameters())
-                            logger.info(f"Checksum at step {curr_step}: {checksum}")
+                            logger.info(f"Loss at step {curr_step}: {float(loss.detach().item())}")
+                        except Exception:
+                            pass
+                        # 2) Tiny activation fingerprint: mean over logits for sample 0
+                        try:
+                            act_mean = float(logits[0].detach().float().mean().item())
+                            logger.info(f"ActMean at step {curr_step}: {act_mean}")
                         except Exception:
                             pass
                     self._log_step_time(curr_step, precision, duration)

--- a/superbench/benchmarks/model_benchmarks/pytorch_cnn.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_cnn.py
@@ -3,6 +3,8 @@
 
 """Module of the Pytorch CNN models."""
 
+import os
+import random
 import torch
 from torchvision import models
 
@@ -35,6 +37,20 @@ class PytorchCNN(PytorchBase):
         self._optimizer_type = Optimizer.SGD
         self._loss_fn = torch.nn.CrossEntropyLoss()
 
+    def _enable_deterministic_training(self):
+        """Enable deterministic training settings for reproducible results."""
+        if hasattr(self._args, 'random_seed'):
+            torch.manual_seed(self._args.random_seed)
+            random.seed(self._args.random_seed)
+            if torch.cuda.is_available():
+                torch.cuda.manual_seed(self._args.random_seed)
+                torch.cuda.manual_seed_all(self._args.random_seed)
+
+        strict = os.environ.get('SB_STRICT_DETERMINISM', '0') == '1'
+        torch.use_deterministic_algorithms(True, warn_only=not strict)
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
+
     def add_parser_arguments(self):
         """Add the CNN-specified arguments."""
         super().add_parser_arguments()
@@ -42,6 +58,19 @@ class PytorchCNN(PytorchBase):
         self._parser.add_argument('--model_type', type=str, required=True, help='The cnn benchmark to run.')
         self._parser.add_argument('--image_size', type=int, default=224, required=False, help='Image size.')
         self._parser.add_argument('--num_classes', type=int, default=1000, required=False, help='Num of class.')
+        self._parser.add_argument(
+            '--random_seed',
+            type=int,
+            default=42,
+            required=False,
+            help='Random seed for deterministic training.'
+        )
+        self._parser.add_argument(
+            '--deterministic',
+            action='store_true',
+            default=False,
+            help='Enable deterministic training for reproducible results.'
+        )
 
     def _generate_dataset(self):
         """Generate dataset for benchmarking according to shape info.
@@ -49,6 +78,9 @@ class PytorchCNN(PytorchBase):
         Return:
             True if dataset is created successfully.
         """
+        if getattr(self._args, 'deterministic', False) and hasattr(self._args, 'random_seed'):
+            torch.manual_seed(self._args.random_seed)
+
         self._dataset = TorchRandomDataset(
             [self._args.sample_count, 3, self._args.image_size, self._args.image_size],
             self._world_size,
@@ -67,6 +99,8 @@ class PytorchCNN(PytorchBase):
             precision (Precision): precision of model and input data, such as float32, float16.
         """
         try:
+            if getattr(self._args, 'deterministic', False):
+                self._enable_deterministic_training()
             self._model = getattr(models, self._args.model_type)()
             self._model = self._model.to(dtype=getattr(torch, precision.value))
             self._model = _keep_BatchNorm_as_float(self._model)
@@ -80,6 +114,8 @@ class PytorchCNN(PytorchBase):
             )
             return False
 
+        if getattr(self._args, 'deterministic', False) and hasattr(self._args, 'random_seed'):
+            torch.manual_seed(self._args.random_seed + 1)
         self._target = torch.LongTensor(self._args.batch_size).random_(self._args.num_classes)
         if self._gpu_available:
             self._target = self._target.cuda()
@@ -96,6 +132,7 @@ class PytorchCNN(PytorchBase):
             The step-time list of every training step.
         """
         duration = []
+        losses = []
         curr_step = 0
         check_frequency = 100
         while True:
@@ -106,7 +143,8 @@ class PytorchCNN(PytorchBase):
                     sample = sample.cuda()
                 self._optimizer.zero_grad()
                 output = self._model(sample)
-                loss = self._loss_fn(output, self._target)
+                # Compute loss in float32 for stability
+                loss = self._loss_fn(output.float(), self._target)
                 loss.backward()
                 self._optimizer.step()
                 end = self._timer()
@@ -114,9 +152,20 @@ class PytorchCNN(PytorchBase):
                 if curr_step > self._args.num_warmup:
                     # Save the step time of every training/inference step, unit is millisecond.
                     duration.append((end - start) * 1000)
+                    try:
+                        losses.append(float(loss.detach().item()))
+                    except Exception:
+                        pass
+                    if getattr(self._args, 'deterministic', False) and (curr_step % check_frequency == 0):
+                        try:
+                            checksum = sum(p.detach().float().sum().item() for p in self._model.parameters())
+                            logger.info(f"Checksum at step {curr_step}: {checksum}")
+                        except Exception:
+                            pass
                     self._log_step_time(curr_step, precision, duration)
                 if self._is_finished(curr_step, end, check_frequency):
-                    return duration
+                    info = {'loss': losses}
+                    return (duration, info)
 
     def _inference_step(self, precision):
         """Define the inference process.
@@ -130,6 +179,7 @@ class PytorchCNN(PytorchBase):
         """
         duration = []
         curr_step = 0
+        check_frequency = 100
         with torch.no_grad():
             self._model.eval()
             while True:
@@ -145,8 +195,22 @@ class PytorchCNN(PytorchBase):
                         # Save the step time of every training/inference step, unit is millisecond.
                         duration.append((end - start) * 1000)
                         self._log_step_time(curr_step, precision, duration)
-                    if self._is_finished(curr_step, end):
+                    if self._is_finished(curr_step, end, check_frequency):
                         return duration
+
+    def _process_info(self, model_action, precision, info):
+        """Persist extra step-level signals (e.g., loss) into raw_data."""
+        try:
+            if not info:
+                return
+            precision_metric = {'float16': 'fp16', 'float32': 'fp32', 'float64': 'fp64', 'bfloat16': 'bf16'}
+            prec_value = precision.value if hasattr(precision, 'value') else str(precision)
+            prefix = precision_metric.get(prec_value, prec_value)
+            metric_loss = f"{prefix}_{model_action}_loss"
+            if 'loss' in info and isinstance(info['loss'], list) and len(info['loss']) > 0:
+                self._result.add_raw_data(metric_loss, info['loss'], self._args.log_raw_data)
+        except Exception:
+            pass
 
 
 # Register CNN benchmarks.

--- a/superbench/benchmarks/model_benchmarks/pytorch_cnn.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_cnn.py
@@ -157,9 +157,15 @@ class PytorchCNN(PytorchBase):
                     except Exception:
                         pass
                     if getattr(self._args, 'deterministic', False) and (curr_step % check_frequency == 0):
+                        # Loss fingerprint
                         try:
-                            checksum = sum(p.detach().float().sum().item() for p in self._model.parameters())
-                            logger.info(f"Checksum at step {curr_step}: {checksum}")
+                            logger.info(f"Loss at step {curr_step}: {float(loss.detach().item())}")
+                        except Exception:
+                            pass
+                        # Activation fingerprint: mean over logits for sample 0
+                        try:
+                            act_mean = float(output[0].detach().float().mean().item())
+                            logger.info(f"ActMean at step {curr_step}: {act_mean}")
                         except Exception:
                             pass
                     self._log_step_time(curr_step, precision, duration)

--- a/superbench/benchmarks/model_benchmarks/pytorch_gpt2.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_gpt2.py
@@ -226,9 +226,15 @@ class PytorchGPT2(PytorchBase):
                     except Exception:
                         pass
                     if getattr(self._args, 'deterministic', False) and (curr_step % check_frequency == 0):
+                        # Loss fingerprint
                         try:
-                            checksum = sum(p.detach().float().sum().item() for p in self._model.parameters())
-                            logger.info(f"Checksum at step {curr_step}: {checksum}")
+                            logger.info(f"Loss at step {curr_step}: {float(loss.detach().item())}")
+                        except Exception:
+                            pass
+                        # Activation fingerprint: mean over last-token logits for sample 0
+                        try:
+                            act_mean = float(logits[0].detach().float().mean().item())
+                            logger.info(f"ActMean at step {curr_step}: {act_mean}")
                         except Exception:
                             pass
                     self._log_step_time(curr_step, precision, duration)

--- a/superbench/benchmarks/model_benchmarks/pytorch_lstm.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_lstm.py
@@ -196,9 +196,15 @@ class PytorchLSTM(PytorchBase):
                     except Exception:
                         pass
                     if getattr(self._args, 'deterministic', False) and (curr_step % check_frequency == 0):
+                        # Emit lightweight periodic fingerprints instead of parameter checksum.
                         try:
-                            checksum = sum(p.detach().float().sum().item() for p in self._model.parameters())
-                            logger.info(f"Checksum at step {curr_step}: {checksum}")
+                            fp32_loss = float(loss.detach().float().item())
+                            logger.info(f"Loss at step {curr_step}: {fp32_loss}")
+                        except Exception:
+                            pass
+                        try:
+                            act_mean = float(output.detach().float()[0].mean().item())
+                            logger.info(f"ActMean at step {curr_step}: {act_mean}")
                         except Exception:
                             pass
                     self._log_step_time(curr_step, precision, duration)

--- a/superbench/benchmarks/model_benchmarks/pytorch_mixtral_impl.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_mixtral_impl.py
@@ -260,9 +260,15 @@ class PytorchMixtral(PytorchBase):
                     except Exception:
                         pass
                     if getattr(self._args, 'deterministic', False) and (curr_step % check_frequency == 0):
+                        # Emit lightweight periodic fingerprints instead of parameter checksum.
                         try:
-                            checksum = sum(p.detach().float().sum().item() for p in self._model.parameters())
-                            logger.info(f"Checksum at step {curr_step}: {checksum}")
+                            fp32_loss = float(loss.detach().float().item())
+                            logger.info(f"Loss at step {curr_step}: {fp32_loss}")
+                        except Exception:
+                            pass
+                        try:
+                            act_mean = float(logits.detach().float()[0].mean().item())
+                            logger.info(f"ActMean at step {curr_step}: {act_mean}")
                         except Exception:
                             pass
                     self._log_step_time(curr_step, precision, duration)

--- a/superbench/benchmarks/model_benchmarks/pytorch_mixtral_impl.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_mixtral_impl.py
@@ -3,6 +3,8 @@
 
 """Module of the Pytorch Mixtral model implementation."""
 
+import os
+import random
 import torch
 from transformers import MixtralModel, MixtralConfig
 try:
@@ -68,6 +70,20 @@ class PytorchMixtral(PytorchBase):
         self._optimizer_type = Optimizer.ADAMW
         self._loss_fn = torch.nn.CrossEntropyLoss()
 
+    def _enable_deterministic_training(self):
+        """Enable deterministic training settings for reproducible results."""
+        if hasattr(self._args, 'random_seed'):
+            torch.manual_seed(self._args.random_seed)
+            random.seed(self._args.random_seed)
+            if torch.cuda.is_available():
+                torch.cuda.manual_seed(self._args.random_seed)
+                torch.cuda.manual_seed_all(self._args.random_seed)
+
+        strict = os.environ.get('SB_STRICT_DETERMINISM', '0') == '1'
+        torch.use_deterministic_algorithms(True, warn_only=not strict)
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
+
     def add_parser_arguments(self):
         """Add the Mixtral-specified arguments.
 
@@ -112,6 +128,19 @@ class PytorchMixtral(PytorchBase):
             required=False,
             help='The aux loss factor for the total loss.'
         )
+        self._parser.add_argument(
+            '--random_seed',
+            type=int,
+            default=42,
+            required=False,
+            help='Random seed for deterministic training.'
+        )
+        self._parser.add_argument(
+            '--deterministic',
+            action='store_true',
+            default=False,
+            help='Enable deterministic training for reproducible results.'
+        )
 
     def _generate_dataset(self):
         """Generate dataset for benchmarking according to shape info.
@@ -119,6 +148,9 @@ class PytorchMixtral(PytorchBase):
         Return:
             True if dataset is created successfully.
         """
+        if getattr(self._args, 'deterministic', False) and hasattr(self._args, 'random_seed'):
+            torch.manual_seed(self._args.random_seed)
+
         self._dataset = TorchRandomDataset(
             [self._args.sample_count, self._args.seq_len], self._world_size, dtype=torch.long
         )
@@ -134,6 +166,9 @@ class PytorchMixtral(PytorchBase):
         Args:
             precision (Precision): precision of model and input data, such as float32, float16.
         """
+        if getattr(self._args, 'deterministic', False):
+            self._enable_deterministic_training()
+
         self._config = MixtralConfig(
             hidden_size=self._args.hidden_size,
             num_hidden_layers=self._args.num_hidden_layers,
@@ -179,6 +214,8 @@ class PytorchMixtral(PytorchBase):
             )
             return False
 
+        if getattr(self._args, 'deterministic', False) and hasattr(self._args, 'random_seed'):
+            torch.manual_seed(self._args.random_seed + 1)
         self._target = torch.LongTensor(self._args.batch_size).random_(self._args.num_classes)
         if self._gpu_available:
             self._target = self._target.cuda()
@@ -195,6 +232,7 @@ class PytorchMixtral(PytorchBase):
             The step-time list of every training step.
         """
         duration = []
+        losses = []
         curr_step = 0
         check_frequency = 100
         while True:
@@ -208,7 +246,8 @@ class PytorchMixtral(PytorchBase):
                         output = self._model(sample)
                 else:
                     output = self._model(sample)
-                loss = self._loss_fn(output[range(self._args.batch_size), -1], self._target)
+                logits = output[range(self._args.batch_size), -1]
+                loss = self._loss_fn(logits.float(), self._target)
                 loss.backward()
                 self._optimizer.step()
                 end = self._timer()
@@ -216,9 +255,20 @@ class PytorchMixtral(PytorchBase):
                 if curr_step > self._args.num_warmup:
                     # Save the step time of every training/inference step, unit is millisecond.
                     duration.append((end - start) * 1000)
+                    try:
+                        losses.append(float(loss.detach().item()))
+                    except Exception:
+                        pass
+                    if getattr(self._args, 'deterministic', False) and (curr_step % check_frequency == 0):
+                        try:
+                            checksum = sum(p.detach().float().sum().item() for p in self._model.parameters())
+                            logger.info(f"Checksum at step {curr_step}: {checksum}")
+                        except Exception:
+                            pass
                     self._log_step_time(curr_step, precision, duration)
                 if self._is_finished(curr_step, end, check_frequency):
-                    return duration
+                    info = {'loss': losses}
+                    return (duration, info)
 
     def _inference_step(self, precision):
         """Define the inference process.
@@ -232,6 +282,7 @@ class PytorchMixtral(PytorchBase):
         """
         duration = []
         curr_step = 0
+        check_frequency = 100
         with torch.no_grad():
             self._model.eval()
             while True:
@@ -250,5 +301,19 @@ class PytorchMixtral(PytorchBase):
                         # Save the step time of every training/inference step, unit is millisecond.
                         duration.append((end - start) * 1000)
                         self._log_step_time(curr_step, precision, duration)
-                    if self._is_finished(curr_step, end):
+                    if self._is_finished(curr_step, end, check_frequency):
                         return duration
+
+    def _process_info(self, model_action, precision, info):
+        """Persist extra step-level signals (e.g., loss) into raw_data."""
+        try:
+            if not info:
+                return
+            precision_metric = {'float16': 'fp16', 'float32': 'fp32', 'float64': 'fp64', 'bfloat16': 'bf16'}
+            prec_value = precision.value if hasattr(precision, 'value') else str(precision)
+            prefix = precision_metric.get(prec_value, prec_value)
+            metric_loss = f"{prefix}_{model_action}_loss"
+            if 'loss' in info and isinstance(info['loss'], list) and len(info['loss']) > 0:
+                self._result.add_raw_data(metric_loss, info['loss'], self._args.log_raw_data)
+        except Exception:
+            pass

--- a/tests/benchmarks/model_benchmarks/test_pytorch_bert.py
+++ b/tests/benchmarks/model_benchmarks/test_pytorch_bert.py
@@ -6,6 +6,7 @@
 import os
 import logging
 import numpy as np
+import pytest
 
 from tests.helper import decorator
 from superbench.benchmarks import BenchmarkRegistry, Platform, Framework, BenchmarkType, ReturnCode
@@ -116,12 +117,29 @@ def test_pytorch_bert_soft_determinism():
     assert np.isfinite(a1).all() and np.isfinite(a2).all()
     assert np.allclose(a1, a2, rtol=1e-6, atol=1e-7)
 
-
 @decorator.cuda_test
 @decorator.pytorch_test
 def test_pytorch_bert_strict_determinism():
-    """Strict determinism: losses should be exactly equal with strict envs set (pre-init)."""
-    # Rely on deterministic flag and seed; assert exact equality
+    """Strict determinism: exact per-step loss equality under strict envs.
+
+    This test verifies the strongest reproducibility guarantee: with strict determinism
+    enabled and a fixed seed, two runs must produce identical fp32 per-step training
+    losses (bitwise equality).
+
+    Requirements and behavior:
+    - Environment must be set before CUDA init: SB_STRICT_DETERMINISM=1 and
+        CUBLAS_WORKSPACE_CONFIG (":4096:8" or ":16:8").
+    - If these envs are not present, the test is skipped to avoid false failures.
+    - The benchmark is invoked with --deterministic and --random_seed 42.
+    - We compare the raw_data metric 'fp32_train_loss' via np.array_equal.
+
+    Rationale:
+    - Strict mode enforces deterministic kernels (warn_only=False) and will error if any
+        nondeterministic op is used, ensuring reproducible numerics beyond soft determinism.
+    """
+
+    if os.environ.get('SB_STRICT_DETERMINISM') != '1' or 'CUBLAS_WORKSPACE_CONFIG' not in os.environ:
+        pytest.skip('Strict determinism env not set; skipping test.')
 
     params = (
         '--hidden_size 256 --num_hidden_layers 2 --num_attention_heads 4 '
@@ -141,19 +159,3 @@ def test_pytorch_bert_strict_determinism():
     a2 = np.array(b2.raw_data[m_loss][0], dtype=float)
     assert np.isfinite(a1).all() and np.isfinite(a2).all()
     assert np.array_equal(a1, a2)
-
-@decorator.cuda_test
-@decorator.pytorch_test
-def test_pytorch_bert_non_deterministic_training():
-    """Test that non-deterministic training is the default when not specified."""
-    context = BenchmarkRegistry.create_benchmark_context(
-        'gpt2-small',
-        platform=Platform.CUDA,
-    parameters='--hidden_size 256 --num_hidden_layers 2 --num_attention_heads 4 '
-    '--batch_size 1 --seq_len 32 --num_warmup 1 --num_steps 2 --precision float16 --sample_count 2 --model_action train',
-        framework=Framework.PYTORCH
-    )
-    benchmark = BenchmarkRegistry.launch_benchmark(context)
-    assert benchmark and benchmark.return_code == ReturnCode.SUCCESS
-    assert benchmark._args.deterministic == False
-    assert benchmark._args.random_seed == 42

--- a/tests/benchmarks/model_benchmarks/test_pytorch_bert.py
+++ b/tests/benchmarks/model_benchmarks/test_pytorch_bert.py
@@ -3,6 +3,10 @@
 
 """Tests for BERT model benchmarks."""
 
+import os
+import logging
+import numpy as np
+
 from tests.helper import decorator
 from superbench.benchmarks import BenchmarkRegistry, Platform, Framework, BenchmarkType, ReturnCode
 from superbench.benchmarks.model_benchmarks.pytorch_bert import PytorchBERT
@@ -56,3 +60,100 @@ def test_pytorch_bert_base():
         assert (len(benchmark.raw_data[metric]) == benchmark.run_count)
         assert (len(benchmark.raw_data[metric][0]) == benchmark._args.num_steps)
         assert (len(benchmark.result[metric]) == benchmark.run_count)
+
+
+@decorator.cuda_test
+@decorator.pytorch_test
+def test_pytorch_bert_periodic_checksum_logging(caplog):
+    """Emit checksum log at the periodic cadence when deterministic training is enabled."""
+    # Ensure strict mode is off; only periodic checksum gated by deterministic should run
+    os.environ.pop('SB_STRICT_DETERMINISM', None)
+    os.environ.pop('CUBLAS_WORKSPACE_CONFIG', None)
+
+    caplog.set_level(logging.INFO, logger='superbench')
+
+    parameters = (
+        '--hidden_size 256 --num_hidden_layers 2 --num_attention_heads 4 '
+        '--intermediate_size 1024 --batch_size 1 --seq_len 16 --num_warmup 1 --num_steps 100 '
+        '--precision float32 --sample_count 2 --deterministic --random_seed 42 --model_action train'
+    )
+
+    context = BenchmarkRegistry.create_benchmark_context(
+        'bert-base', platform=Platform.CUDA, parameters=parameters, framework=Framework.PYTORCH
+    )
+    benchmark = BenchmarkRegistry.launch_benchmark(context)
+
+    assert benchmark and benchmark.return_code == ReturnCode.SUCCESS
+
+    # Expect one checksum log at step 100 (cadence = 100)
+    messages = [rec.getMessage() for rec in caplog.records if rec.name == 'superbench']
+    assert any('Checksum at step 100:' in m for m in messages)
+
+
+@decorator.cuda_test
+@decorator.pytorch_test
+def test_pytorch_bert_soft_determinism():
+    """Soft determinism: losses should be numerically close across runs without strict envs."""
+    os.environ.pop('SB_STRICT_DETERMINISM', None)
+    os.environ.pop('CUBLAS_WORKSPACE_CONFIG', None)
+
+    params = (
+        '--hidden_size 256 --num_hidden_layers 2 --num_attention_heads 4 '
+        '--intermediate_size 1024 --batch_size 1 --seq_len 32 --num_warmup 1 --num_steps 2 '
+        '--precision float32 --sample_count 2 --deterministic --random_seed 42 --model_action train'
+    )
+
+    ctx1 = BenchmarkRegistry.create_benchmark_context('bert-base', platform=Platform.CUDA, parameters=params, framework=Framework.PYTORCH)
+    b1 = BenchmarkRegistry.launch_benchmark(ctx1)
+    ctx2 = BenchmarkRegistry.create_benchmark_context('bert-base', platform=Platform.CUDA, parameters=params, framework=Framework.PYTORCH)
+    b2 = BenchmarkRegistry.launch_benchmark(ctx2)
+
+    assert b1 and b2 and b1.return_code == ReturnCode.SUCCESS and b2.return_code == ReturnCode.SUCCESS
+
+    m_loss = 'fp32_train_loss'
+    a1 = np.array(b1.raw_data[m_loss][0], dtype=float)
+    a2 = np.array(b2.raw_data[m_loss][0], dtype=float)
+    assert np.isfinite(a1).all() and np.isfinite(a2).all()
+    assert np.allclose(a1, a2, rtol=1e-6, atol=1e-7)
+
+
+@decorator.cuda_test
+@decorator.pytorch_test
+def test_pytorch_bert_strict_determinism():
+    """Strict determinism: losses should be exactly equal with strict envs set (pre-init)."""
+    # Rely on deterministic flag and seed; assert exact equality
+
+    params = (
+        '--hidden_size 256 --num_hidden_layers 2 --num_attention_heads 4 '
+        '--intermediate_size 1024 --batch_size 1 --seq_len 32 --num_warmup 1 --num_steps 2 '
+        '--precision float32 --sample_count 2 --deterministic --random_seed 42 --model_action train'
+    )
+
+    ctx1 = BenchmarkRegistry.create_benchmark_context('bert-base', platform=Platform.CUDA, parameters=params, framework=Framework.PYTORCH)
+    b1 = BenchmarkRegistry.launch_benchmark(ctx1)
+    ctx2 = BenchmarkRegistry.create_benchmark_context('bert-base', platform=Platform.CUDA, parameters=params, framework=Framework.PYTORCH)
+    b2 = BenchmarkRegistry.launch_benchmark(ctx2)
+
+    assert b1 and b2 and b1.return_code == ReturnCode.SUCCESS and b2.return_code == ReturnCode.SUCCESS
+
+    m_loss = 'fp32_train_loss'
+    a1 = np.array(b1.raw_data[m_loss][0], dtype=float)
+    a2 = np.array(b2.raw_data[m_loss][0], dtype=float)
+    assert np.isfinite(a1).all() and np.isfinite(a2).all()
+    assert np.array_equal(a1, a2)
+
+@decorator.cuda_test
+@decorator.pytorch_test
+def test_pytorch_bert_non_deterministic_training():
+    """Test that non-deterministic training is the default when not specified."""
+    context = BenchmarkRegistry.create_benchmark_context(
+        'gpt2-small',
+        platform=Platform.CUDA,
+    parameters='--hidden_size 256 --num_hidden_layers 2 --num_attention_heads 4 '
+    '--batch_size 1 --seq_len 32 --num_warmup 1 --num_steps 2 --precision float16 --sample_count 2 --model_action train',
+        framework=Framework.PYTORCH
+    )
+    benchmark = BenchmarkRegistry.launch_benchmark(context)
+    assert benchmark and benchmark.return_code == ReturnCode.SUCCESS
+    assert benchmark._args.deterministic == False
+    assert benchmark._args.random_seed == 42

--- a/tests/benchmarks/model_benchmarks/test_pytorch_bert.py
+++ b/tests/benchmarks/model_benchmarks/test_pytorch_bert.py
@@ -65,8 +65,8 @@ def test_pytorch_bert_base():
 
 @decorator.cuda_test
 @decorator.pytorch_test
-def test_pytorch_bert_periodic_checksum_logging(caplog):
-    """Emit checksum log at the periodic cadence when deterministic training is enabled."""
+def test_pytorch_bert_periodic_fingerprint_logging(caplog):
+    """Emit loss and activation fingerprints at the periodic cadence when deterministic training is enabled."""
     # Ensure strict mode is off; only periodic checksum gated by deterministic should run
     os.environ.pop('SB_STRICT_DETERMINISM', None)
     os.environ.pop('CUBLAS_WORKSPACE_CONFIG', None)
@@ -86,9 +86,10 @@ def test_pytorch_bert_periodic_checksum_logging(caplog):
 
     assert benchmark and benchmark.return_code == ReturnCode.SUCCESS
 
-    # Expect one checksum log at step 100 (cadence = 100)
+    # Expect loss and activation logs at step 100 (cadence = 100)
     messages = [rec.getMessage() for rec in caplog.records if rec.name == 'superbench']
-    assert any('Checksum at step 100:' in m for m in messages)
+    assert any('Loss at step 100:' in m for m in messages)
+    assert any('ActMean at step 100:' in m for m in messages)
 
 
 @decorator.cuda_test

--- a/tests/benchmarks/model_benchmarks/test_pytorch_cnn.py
+++ b/tests/benchmarks/model_benchmarks/test_pytorch_cnn.py
@@ -83,8 +83,8 @@ def run_pytorch_cnn(models=[], parameters='', check_metrics=[]):
 
 @decorator.cuda_test
 @decorator.pytorch_test
-def test_pytorch_cnn_periodic_checksum_logging(caplog):
-    """Emit checksum log at the periodic cadence when deterministic training is enabled."""
+def test_pytorch_cnn_periodic_fingerprint_logging(caplog):
+    """Emit loss and activation fingerprints at the periodic cadence when deterministic training is enabled."""
     os.environ.pop('SB_STRICT_DETERMINISM', None)
     os.environ.pop('CUBLAS_WORKSPACE_CONFIG', None)
 
@@ -104,7 +104,8 @@ def test_pytorch_cnn_periodic_checksum_logging(caplog):
     assert benchmark and benchmark.return_code == ReturnCode.SUCCESS
 
     messages = [rec.getMessage() for rec in caplog.records if rec.name == 'superbench']
-    assert any('Checksum at step 100:' in m for m in messages)
+    assert any('Loss at step 100:' in m for m in messages)
+    assert any('ActMean at step 100:' in m for m in messages)
 
 
 @decorator.cuda_test

--- a/tests/benchmarks/model_benchmarks/test_pytorch_cnn.py
+++ b/tests/benchmarks/model_benchmarks/test_pytorch_cnn.py
@@ -6,6 +6,7 @@
 import os
 import logging
 import numpy as np
+import pytest
 
 from tests.helper import decorator
 from superbench.benchmarks import BenchmarkRegistry, Platform, Framework, BenchmarkType, ReturnCode
@@ -130,7 +131,26 @@ def test_pytorch_cnn_soft_determinism():
 @decorator.cuda_test
 @decorator.pytorch_test
 def test_pytorch_cnn_strict_determinism():
-    # Rely on deterministic flag and seed; assert exact equality
+    """Strict determinism: exact per-step loss equality under strict envs.
+
+    This test verifies the strongest reproducibility guarantee: with strict determinism
+    enabled and a fixed seed, two runs must produce identical fp32 per-step training
+    losses (bitwise equality).
+
+    Requirements and behavior:
+    - Environment must be set before CUDA init: SB_STRICT_DETERMINISM=1 and
+        CUBLAS_WORKSPACE_CONFIG (":4096:8" or ":16:8").
+    - If these envs are not present, the test is skipped to avoid false failures.
+    - The benchmark is invoked with --deterministic and --random_seed 42.
+    - We compare the raw_data metric 'fp32_train_loss' via np.array_equal.
+
+    Rationale:
+    - Strict mode enforces deterministic kernels (warn_only=False) and will error if any
+        nondeterministic op is used, ensuring reproducible numerics beyond soft determinism.
+    """
+
+    if os.environ.get('SB_STRICT_DETERMINISM') != '1' or 'CUBLAS_WORKSPACE_CONFIG' not in os.environ:
+        pytest.skip('Strict determinism env not set; skipping test.')
     params = (
         '--batch_size 1 --image_size 64 --num_classes 5 --num_warmup 1 --num_steps 2 '
         '--precision float32 --deterministic --random_seed 42 --model_action train'
@@ -145,19 +165,3 @@ def test_pytorch_cnn_strict_determinism():
     a2 = np.array(b2.raw_data[m_loss][0], dtype=float)
     assert np.isfinite(a1).all() and np.isfinite(a2).all()
     assert np.array_equal(a1, a2)
-
-@decorator.cuda_test
-@decorator.pytorch_test
-def test_pytorch_cnn_non_deterministic_training():
-    """Test that non-deterministic training is the default when not specified."""
-    context = BenchmarkRegistry.create_benchmark_context(
-        'gpt2-small',
-        platform=Platform.CUDA,
-    parameters='--batch_size 1 --num_classes 5 --seq_len 32 --num_warmup 1 --num_steps 2 --precision float16 --model_action train',
-        framework=Framework.PYTORCH
-    )
-    benchmark = BenchmarkRegistry.launch_benchmark(context)
-    assert benchmark and benchmark.return_code == ReturnCode.SUCCESS
-    assert benchmark._args.deterministic == False
-    assert benchmark._args.random_seed == 42
-

--- a/tests/benchmarks/model_benchmarks/test_pytorch_cnn.py
+++ b/tests/benchmarks/model_benchmarks/test_pytorch_cnn.py
@@ -3,6 +3,10 @@
 
 """Tests for CNN model benchmarks."""
 
+import os
+import logging
+import numpy as np
+
 from tests.helper import decorator
 from superbench.benchmarks import BenchmarkRegistry, Platform, Framework, BenchmarkType, ReturnCode
 from superbench.benchmarks.model_benchmarks.pytorch_cnn import PytorchCNN
@@ -74,3 +78,86 @@ def run_pytorch_cnn(models=[], parameters='', check_metrics=[]):
             assert (len(benchmark.raw_data[metric]) == benchmark.run_count)
             assert (len(benchmark.raw_data[metric][0]) == benchmark._args.num_steps)
             assert (len(benchmark.result[metric]) == benchmark.run_count)
+
+
+@decorator.cuda_test
+@decorator.pytorch_test
+def test_pytorch_cnn_periodic_checksum_logging(caplog):
+    """Emit checksum log at the periodic cadence when deterministic training is enabled."""
+    os.environ.pop('SB_STRICT_DETERMINISM', None)
+    os.environ.pop('CUBLAS_WORKSPACE_CONFIG', None)
+
+    caplog.set_level(logging.INFO, logger='superbench')
+
+    # Use a relatively small model for speed
+    parameters = (
+        '--batch_size 1 --image_size 64 --num_classes 5 --num_warmup 1 --num_steps 100 '
+        '--precision float32 --deterministic --random_seed 42 --model_action train'
+    )
+
+    context = BenchmarkRegistry.create_benchmark_context(
+        'resnet18', platform=Platform.CUDA, parameters=parameters, framework=Framework.PYTORCH
+    )
+    benchmark = BenchmarkRegistry.launch_benchmark(context)
+
+    assert benchmark and benchmark.return_code == ReturnCode.SUCCESS
+
+    messages = [rec.getMessage() for rec in caplog.records if rec.name == 'superbench']
+    assert any('Checksum at step 100:' in m for m in messages)
+
+
+@decorator.cuda_test
+@decorator.pytorch_test
+def test_pytorch_cnn_soft_determinism():
+    os.environ.pop('SB_STRICT_DETERMINISM', None)
+    os.environ.pop('CUBLAS_WORKSPACE_CONFIG', None)
+    params = (
+        '--batch_size 1 --image_size 64 --num_classes 5 --num_warmup 1 --num_steps 2 '
+        '--precision float32 --deterministic --random_seed 42 --model_action train'
+    )
+    ctx1 = BenchmarkRegistry.create_benchmark_context('resnet18', platform=Platform.CUDA, parameters=params, framework=Framework.PYTORCH)
+    b1 = BenchmarkRegistry.launch_benchmark(ctx1)
+    ctx2 = BenchmarkRegistry.create_benchmark_context('resnet18', platform=Platform.CUDA, parameters=params, framework=Framework.PYTORCH)
+    b2 = BenchmarkRegistry.launch_benchmark(ctx2)
+    assert b1 and b2 and b1.return_code == ReturnCode.SUCCESS and b2.return_code == ReturnCode.SUCCESS
+    m_loss = 'fp32_train_loss'
+    a1 = np.array(b1.raw_data[m_loss][0], dtype=float)
+    a2 = np.array(b2.raw_data[m_loss][0], dtype=float)
+    assert np.isfinite(a1).all() and np.isfinite(a2).all()
+    assert np.allclose(a1, a2, rtol=1e-6, atol=1e-7)
+
+
+@decorator.cuda_test
+@decorator.pytorch_test
+def test_pytorch_cnn_strict_determinism():
+    # Rely on deterministic flag and seed; assert exact equality
+    params = (
+        '--batch_size 1 --image_size 64 --num_classes 5 --num_warmup 1 --num_steps 2 '
+        '--precision float32 --deterministic --random_seed 42 --model_action train'
+    )
+    ctx1 = BenchmarkRegistry.create_benchmark_context('resnet18', platform=Platform.CUDA, parameters=params, framework=Framework.PYTORCH)
+    b1 = BenchmarkRegistry.launch_benchmark(ctx1)
+    ctx2 = BenchmarkRegistry.create_benchmark_context('resnet18', platform=Platform.CUDA, parameters=params, framework=Framework.PYTORCH)
+    b2 = BenchmarkRegistry.launch_benchmark(ctx2)
+    assert b1 and b2 and b1.return_code == ReturnCode.SUCCESS and b2.return_code == ReturnCode.SUCCESS
+    m_loss = 'fp32_train_loss'
+    a1 = np.array(b1.raw_data[m_loss][0], dtype=float)
+    a2 = np.array(b2.raw_data[m_loss][0], dtype=float)
+    assert np.isfinite(a1).all() and np.isfinite(a2).all()
+    assert np.array_equal(a1, a2)
+
+@decorator.cuda_test
+@decorator.pytorch_test
+def test_pytorch_cnn_non_deterministic_training():
+    """Test that non-deterministic training is the default when not specified."""
+    context = BenchmarkRegistry.create_benchmark_context(
+        'gpt2-small',
+        platform=Platform.CUDA,
+    parameters='--batch_size 1 --num_classes 5 --seq_len 32 --num_warmup 1 --num_steps 2 --precision float16 --model_action train',
+        framework=Framework.PYTORCH
+    )
+    benchmark = BenchmarkRegistry.launch_benchmark(context)
+    assert benchmark and benchmark.return_code == ReturnCode.SUCCESS
+    assert benchmark._args.deterministic == False
+    assert benchmark._args.random_seed == 42
+

--- a/tests/benchmarks/model_benchmarks/test_pytorch_gpt2.py
+++ b/tests/benchmarks/model_benchmarks/test_pytorch_gpt2.py
@@ -64,8 +64,8 @@ def test_pytorch_gpt2_small():
 
 @decorator.cuda_test
 @decorator.pytorch_test
-def test_pytorch_gpt2_periodic_checksum_logging(caplog):
-    """Emit checksum log at the periodic cadence when deterministic training is enabled."""
+def test_pytorch_gpt2_periodic_fingerprint_logging(caplog):
+    """Emit loss and activation fingerprints at the periodic cadence when deterministic training is enabled."""
     os.environ.pop('SB_STRICT_DETERMINISM', None)
     os.environ.pop('CUBLAS_WORKSPACE_CONFIG', None)
 
@@ -85,7 +85,8 @@ def test_pytorch_gpt2_periodic_checksum_logging(caplog):
     assert benchmark and benchmark.return_code == ReturnCode.SUCCESS
 
     messages = [rec.getMessage() for rec in caplog.records if rec.name == 'superbench']
-    assert any('Checksum at step 100:' in m for m in messages)
+    assert any('Loss at step 100:' in m for m in messages)
+    assert any('ActMean at step 100:' in m for m in messages)
 
 
 @decorator.cuda_test

--- a/tests/benchmarks/model_benchmarks/test_pytorch_gpt2.py
+++ b/tests/benchmarks/model_benchmarks/test_pytorch_gpt2.py
@@ -6,6 +6,7 @@
 import os
 import logging
 import numpy as np
+import pytest
 
 from tests.helper import decorator
 from superbench.benchmarks import BenchmarkRegistry, Platform, Framework, BenchmarkType, ReturnCode
@@ -113,7 +114,25 @@ def test_pytorch_gpt2_soft_determinism():
 @decorator.cuda_test
 @decorator.pytorch_test
 def test_pytorch_gpt2_strict_determinism():
-    # Rely on deterministic flag and seed; assert exact equality
+    """Strict determinism: exact per-step loss equality under strict envs.
+
+    This test verifies the strongest reproducibility guarantee: with strict determinism
+    enabled and a fixed seed, two runs must produce identical fp32 per-step training
+    losses (bitwise equality).
+
+    Requirements and behavior:
+    - Environment must be set before CUDA init: SB_STRICT_DETERMINISM=1 and
+        CUBLAS_WORKSPACE_CONFIG (":4096:8" or ":16:8").
+    - If these envs are not present, the test is skipped to avoid false failures.
+    - The benchmark is invoked with --deterministic and --random_seed 42.
+    - We compare the raw_data metric 'fp32_train_loss' via np.array_equal.
+
+    Rationale:
+    - Strict mode enforces deterministic kernels (warn_only=False) and will error if any
+        nondeterministic op is used, ensuring reproducible numerics beyond soft determinism.
+    """
+    if os.environ.get('SB_STRICT_DETERMINISM') != '1' or 'CUBLAS_WORKSPACE_CONFIG' not in os.environ:
+        pytest.skip('Strict determinism env not set; skipping test.')
     params = (
         '--hidden_size 256 --num_hidden_layers 2 --num_attention_heads 4 '
         '--batch_size 1 --seq_len 32 --num_warmup 1 --num_steps 2 '
@@ -129,19 +148,3 @@ def test_pytorch_gpt2_strict_determinism():
     a2 = np.array(b2.raw_data[m_loss][0], dtype=float)
     assert np.isfinite(a1).all() and np.isfinite(a2).all()
     assert np.array_equal(a1, a2)
-
-
-@decorator.cuda_test
-@decorator.pytorch_test
-def test_pytorch_gpt2_non_deterministic_training():
-    """Test that non-deterministic training is the default when not specified."""
-    context = BenchmarkRegistry.create_benchmark_context(
-        'gpt2-small',
-        platform=Platform.CUDA,
-        parameters='--hidden_size 256 --num_hidden_layers 2 --num_attention_heads 4 --batch_size 1 --seq_len 16 --num_warmup 1 --num_steps 2 --precision float16 --model_action train',
-        framework=Framework.PYTORCH
-    )
-    benchmark = BenchmarkRegistry.launch_benchmark(context)
-    assert benchmark and benchmark.return_code == ReturnCode.SUCCESS
-    assert benchmark._args.deterministic == False
-    assert benchmark._args.random_seed == 42

--- a/tests/benchmarks/model_benchmarks/test_pytorch_gpt2.py
+++ b/tests/benchmarks/model_benchmarks/test_pytorch_gpt2.py
@@ -3,6 +3,10 @@
 
 """Tests for GPT2 model benchmarks."""
 
+import os
+import logging
+import numpy as np
+
 from tests.helper import decorator
 from superbench.benchmarks import BenchmarkRegistry, Platform, Framework, BenchmarkType, ReturnCode
 from superbench.benchmarks.model_benchmarks.pytorch_gpt2 import PytorchGPT2
@@ -55,3 +59,89 @@ def test_pytorch_gpt2_small():
         assert (len(benchmark.raw_data[metric]) == benchmark.run_count)
         assert (len(benchmark.raw_data[metric][0]) == benchmark._args.num_steps)
         assert (len(benchmark.result[metric]) == benchmark.run_count)
+
+
+@decorator.cuda_test
+@decorator.pytorch_test
+def test_pytorch_gpt2_periodic_checksum_logging(caplog):
+    """Emit checksum log at the periodic cadence when deterministic training is enabled."""
+    os.environ.pop('SB_STRICT_DETERMINISM', None)
+    os.environ.pop('CUBLAS_WORKSPACE_CONFIG', None)
+
+    caplog.set_level(logging.INFO, logger='superbench')
+
+    parameters = (
+        '--hidden_size 256 --num_hidden_layers 2 --num_attention_heads 4 '
+        '--batch_size 1 --seq_len 16 --num_warmup 1 --num_steps 100 '
+        '--precision float32 --sample_count 2 --deterministic --random_seed 42 --model_action train'
+    )
+
+    context = BenchmarkRegistry.create_benchmark_context(
+        'gpt2-small', platform=Platform.CUDA, parameters=parameters, framework=Framework.PYTORCH
+    )
+    benchmark = BenchmarkRegistry.launch_benchmark(context)
+
+    assert benchmark and benchmark.return_code == ReturnCode.SUCCESS
+
+    messages = [rec.getMessage() for rec in caplog.records if rec.name == 'superbench']
+    assert any('Checksum at step 100:' in m for m in messages)
+
+
+@decorator.cuda_test
+@decorator.pytorch_test
+def test_pytorch_gpt2_soft_determinism():
+    os.environ.pop('SB_STRICT_DETERMINISM', None)
+    os.environ.pop('CUBLAS_WORKSPACE_CONFIG', None)
+
+    params = (
+        '--hidden_size 256 --num_hidden_layers 2 --num_attention_heads 4 '
+        '--batch_size 1 --seq_len 32 --num_warmup 1 --num_steps 2 '
+        '--precision float32 --sample_count 2 --deterministic --random_seed 42 --model_action train'
+    )
+    c1 = BenchmarkRegistry.create_benchmark_context('gpt2-small', platform=Platform.CUDA, parameters=params, framework=Framework.PYTORCH)
+    b1 = BenchmarkRegistry.launch_benchmark(c1)
+    c2 = BenchmarkRegistry.create_benchmark_context('gpt2-small', platform=Platform.CUDA, parameters=params, framework=Framework.PYTORCH)
+    b2 = BenchmarkRegistry.launch_benchmark(c2)
+    assert b1 and b2 and b1.return_code == ReturnCode.SUCCESS and b2.return_code == ReturnCode.SUCCESS
+    m_loss = 'fp32_train_loss'
+    a1 = np.array(b1.raw_data[m_loss][0], dtype=float)
+    a2 = np.array(b2.raw_data[m_loss][0], dtype=float)
+    assert np.isfinite(a1).all() and np.isfinite(a2).all()
+    assert np.allclose(a1, a2, rtol=1e-6, atol=1e-7)
+
+
+@decorator.cuda_test
+@decorator.pytorch_test
+def test_pytorch_gpt2_strict_determinism():
+    # Rely on deterministic flag and seed; assert exact equality
+    params = (
+        '--hidden_size 256 --num_hidden_layers 2 --num_attention_heads 4 '
+        '--batch_size 1 --seq_len 32 --num_warmup 1 --num_steps 2 '
+        '--precision float32 --sample_count 2 --deterministic --random_seed 42 --model_action train'
+    )
+    c1 = BenchmarkRegistry.create_benchmark_context('gpt2-small', platform=Platform.CUDA, parameters=params, framework=Framework.PYTORCH)
+    b1 = BenchmarkRegistry.launch_benchmark(c1)
+    c2 = BenchmarkRegistry.create_benchmark_context('gpt2-small', platform=Platform.CUDA, parameters=params, framework=Framework.PYTORCH)
+    b2 = BenchmarkRegistry.launch_benchmark(c2)
+    assert b1 and b2 and b1.return_code == ReturnCode.SUCCESS and b2.return_code == ReturnCode.SUCCESS
+    m_loss = 'fp32_train_loss'
+    a1 = np.array(b1.raw_data[m_loss][0], dtype=float)
+    a2 = np.array(b2.raw_data[m_loss][0], dtype=float)
+    assert np.isfinite(a1).all() and np.isfinite(a2).all()
+    assert np.array_equal(a1, a2)
+
+
+@decorator.cuda_test
+@decorator.pytorch_test
+def test_pytorch_gpt2_non_deterministic_training():
+    """Test that non-deterministic training is the default when not specified."""
+    context = BenchmarkRegistry.create_benchmark_context(
+        'gpt2-small',
+        platform=Platform.CUDA,
+        parameters='--hidden_size 256 --num_hidden_layers 2 --num_attention_heads 4 --batch_size 1 --seq_len 16 --num_warmup 1 --num_steps 2 --precision float16 --model_action train',
+        framework=Framework.PYTORCH
+    )
+    benchmark = BenchmarkRegistry.launch_benchmark(context)
+    assert benchmark and benchmark.return_code == ReturnCode.SUCCESS
+    assert benchmark._args.deterministic == False
+    assert benchmark._args.random_seed == 42

--- a/tests/benchmarks/model_benchmarks/test_pytorch_llama.py
+++ b/tests/benchmarks/model_benchmarks/test_pytorch_llama.py
@@ -62,15 +62,15 @@ def test_pytorch_llama_7b():
 
 @decorator.cuda_test
 @decorator.pytorch_test
-def test_pytorch_llama_periodic_checksum_logging(caplog):
-    """Emit checksum log at the periodic cadence when deterministic training is enabled.
+def test_pytorch_llama_periodic_fingerprint_logging(caplog):
+    """Emit loss and activation fingerprints at the periodic cadence with deterministic training.
 
     This test ensures that when deterministic training is enabled (but strict mode is off),
-    the periodic checksum logging is triggered at the expected cadence.
+    the periodic loss and activation fingerprint logging is triggered at the expected cadence.
 
-    - Strict mode envs are explicitly unset to test only the periodic checksum behavior.
+    - Strict mode envs are explicitly unset to test only the periodic fingerprint behavior.
     - The benchmark is run with --deterministic and --random_seed 42.
-    - We expect a checksum log at step 100 (cadence = 100).
+    - We expect both a Loss and an ActMean log at step 100 (cadence = 100).
     """
     os.environ.pop('SB_STRICT_DETERMINISM', None)
     os.environ.pop('CUBLAS_WORKSPACE_CONFIG', None)
@@ -90,9 +90,10 @@ def test_pytorch_llama_periodic_checksum_logging(caplog):
 
     assert benchmark and benchmark.return_code == ReturnCode.SUCCESS
 
-    # Expect one checksum log at step 100 (cadence = 100)
+    # Expect one loss and one activation fingerprint log at step 100 (cadence = 100)
     messages = [rec.getMessage() for rec in caplog.records if rec.name == 'superbench']
-    assert any('Checksum at step 100:' in m for m in messages)
+    assert any('Loss at step 100:' in m for m in messages)
+    assert any('ActMean at step 100:' in m for m in messages)
 
 @decorator.cuda_test
 @decorator.pytorch_test

--- a/tests/benchmarks/model_benchmarks/test_pytorch_llama.py
+++ b/tests/benchmarks/model_benchmarks/test_pytorch_llama.py
@@ -3,6 +3,7 @@
 
 """Tests for Llama model benchmarks."""
 
+import torch
 from tests.helper import decorator
 from superbench.benchmarks import BenchmarkRegistry, Platform, Framework, BenchmarkType, ReturnCode
 from superbench.benchmarks.model_benchmarks.pytorch_llama import PytorchLlama
@@ -55,3 +56,98 @@ def test_pytorch_llama_7b():
         assert (len(benchmark.raw_data[metric]) == benchmark.run_count)
         assert (len(benchmark.raw_data[metric][0]) == benchmark._args.num_steps)
         assert (len(benchmark.result[metric]) == benchmark.run_count)
+
+
+@decorator.cuda_test
+@decorator.pytorch_test
+def test_pytorch_llama_deterministic_training():
+    """Test pytorch-llama2-7b benchmark with deterministic training enabled."""
+    # Test that deterministic training parameters work and don't cause crashes
+    context = BenchmarkRegistry.create_benchmark_context(
+        'llama2-7b',
+        platform=Platform.CUDA,
+        parameters='--batch_size 1 --seq_len 32 --num_warmup 1 --num_steps 2 --precision float16 \
+            --model_action train --deterministic --random_seed 42',
+        framework=Framework.PYTORCH
+    )
+
+    assert (BenchmarkRegistry.is_benchmark_context_valid(context))
+
+    # Run benchmark with deterministic settings
+    benchmark = BenchmarkRegistry.launch_benchmark(context)
+
+    # Check that the run succeeded
+    assert (benchmark.return_code == ReturnCode.SUCCESS)
+
+    # Check that deterministic parameters are set correctly
+    assert (benchmark._args.deterministic == True)
+    assert (benchmark._args.random_seed == 42)
+
+    # Check that we have valid results (deterministic training should still produce results)
+    assert 'fp16_train_step_time' in benchmark.result
+    assert len(benchmark.result['fp16_train_step_time']) > 0
+    assert all(isinstance(x, (int, float)) and x > 0 for x in benchmark.result['fp16_train_step_time'])
+
+    # Check that throughput results are also valid
+    if 'fp16_train_throughput' in benchmark.result:
+        assert len(benchmark.result['fp16_train_throughput']) > 0
+        assert all(isinstance(x, (int, float)) and x > 0 for x in benchmark.result['fp16_train_throughput'])
+
+    # Verify that the benchmark completes without errors when deterministic mode is enabled
+    # (This validates that our _enable_deterministic_training method works without crashes)
+
+
+@decorator.cuda_test
+@decorator.pytorch_test
+def test_pytorch_llama_non_deterministic_training():
+    """Test pytorch-llama2-7b benchmark with non-deterministic training (default behavior)."""
+    # Test that non-deterministic training works as expected
+    context = BenchmarkRegistry.create_benchmark_context(
+        'llama2-7b',
+        platform=Platform.CUDA,
+        parameters='--batch_size 1 --seq_len 32 --num_warmup 1 --num_steps 2 --precision float16 \
+            --model_action train',
+        framework=Framework.PYTORCH
+    )
+
+    assert (BenchmarkRegistry.is_benchmark_context_valid(context))
+
+    benchmark = BenchmarkRegistry.launch_benchmark(context)
+
+    # Check that benchmark runs successfully
+    assert (benchmark.return_code == ReturnCode.SUCCESS)
+
+    # Check that deterministic is disabled by default
+    assert (benchmark._args.deterministic == False)
+    assert (benchmark._args.random_seed == 42)  # Default value
+
+
+@decorator.cuda_test
+@decorator.pytorch_test
+def test_pytorch_llama_deterministic_parameters():
+    """Test pytorch-llama2-7b benchmark parameter parsing for deterministic training."""
+    # Test parameter parsing for deterministic training
+    context = BenchmarkRegistry.create_benchmark_context(
+        'llama2-7b',
+        platform=Platform.CUDA,
+        parameters='--batch_size 1 --seq_len 32 --num_warmup 1 --num_steps 2 --precision float16 \
+            --model_action train --deterministic --random_seed 123',
+        framework=Framework.PYTORCH
+    )
+
+    assert (BenchmarkRegistry.is_benchmark_context_valid(context))
+
+    benchmark = BenchmarkRegistry.launch_benchmark(context)
+
+    # Check basic functionality
+    assert (benchmark.return_code == ReturnCode.SUCCESS)
+
+    # Check that parameters are parsed correctly
+    assert (benchmark._args.deterministic == True)
+    assert (benchmark._args.random_seed == 123)
+
+    # Check that all other parameters are still working
+    assert (benchmark._args.batch_size == 1)
+    assert (benchmark._args.seq_len == 32)
+    assert (benchmark._args.num_warmup == 1)
+    assert (benchmark._args.num_steps == 2)

--- a/tests/benchmarks/model_benchmarks/test_pytorch_llama.py
+++ b/tests/benchmarks/model_benchmarks/test_pytorch_llama.py
@@ -4,13 +4,13 @@
 """Tests for Llama model benchmarks."""
 
 import os
+import pytest
 import torch
 import numpy as np
 import logging
 from tests.helper import decorator
 from superbench.benchmarks import BenchmarkRegistry, Platform, Framework, BenchmarkType, ReturnCode, Precision
 from superbench.benchmarks.model_benchmarks.pytorch_llama import PytorchLlama
-
 
 @decorator.cuda_test
 @decorator.pytorch_test
@@ -60,76 +60,32 @@ def test_pytorch_llama_7b():
         assert (len(benchmark.raw_data[metric][0]) == benchmark._args.num_steps)
         assert (len(benchmark.result[metric]) == benchmark.run_count)
 
-
 @decorator.cuda_test
 @decorator.pytorch_test
-def test_pytorch_llama_deterministic_training():
-    """Test pytorch-llama2-7b benchmark with deterministic training enabled."""
-    # Test that deterministic training parameters work and don't cause crashes
+def test_pytorch_llama_periodic_checksum_logging(caplog):
+    """Emit checksum log at the periodic cadence when deterministic training is enabled."""
+    # Ensure strict mode is off; only periodic checksum gated by deterministic should run
+    os.environ.pop('SB_STRICT_DETERMINISM', None)
+    os.environ.pop('CUBLAS_WORKSPACE_CONFIG', None)
 
-    parameters = '--hidden_size 256 --num_hidden_layers 2 --num_attention_heads 4 --num_key_value_heads 4 --intermediate_size 1024 --batch_size 1 --seq_len 32 --num_warmup 1 --num_steps 2 --precision float32 --sample_count 2 --deterministic --random_seed 42 --model_action train'
-    # Run twice with the same seed and deterministic flag using the registry
-    context = BenchmarkRegistry.create_benchmark_context(
-        'llama2-7b',
-        platform=Platform.CUDA,
-        parameters=parameters,
-        framework=Framework.PYTORCH
+    caplog.set_level(logging.INFO, logger='superbench')
+
+    parameters = (
+        '--hidden_size 128 --num_hidden_layers 2 --num_attention_heads 4 --num_key_value_heads 4 '
+        '--intermediate_size 512 --batch_size 1 --seq_len 16 --num_warmup 1 --num_steps 100 '
+        '--precision float32 --sample_count 2 --deterministic --random_seed 42 --model_action train'
     )
-    benchmark1 = BenchmarkRegistry.launch_benchmark(context)
-
-    context2 = BenchmarkRegistry.create_benchmark_context(
-        'llama2-7b',
-        platform=Platform.CUDA,
-        parameters=parameters,
-        framework=Framework.PYTORCH
-    )
-    benchmark2 = BenchmarkRegistry.launch_benchmark(context2)
-
-    # Check that the run succeeded (basic checks)
-    assert (benchmark1)
-    assert (benchmark2)
-    assert (isinstance(benchmark1, PytorchLlama))
-    assert (isinstance(benchmark2, PytorchLlama))
-    assert (benchmark1._args.deterministic == True)
-    assert (benchmark2._args.deterministic == True)
-    assert (benchmark1._args.random_seed == 42)
-    assert (benchmark2._args.random_seed == 42)
-
-    # Validate time metrics exist and shapes are correct (but don't require equality due to scheduler/async noise)
-    m_time = 'fp32_train_step_time'
-    assert m_time in benchmark1.raw_data and m_time in benchmark2.raw_data
-    assert len(benchmark1.raw_data[m_time]) == benchmark1.run_count
-    assert len(benchmark2.raw_data[m_time]) == benchmark2.run_count
-    assert len(benchmark1.raw_data[m_time][0]) == benchmark1._args.num_steps
-    assert len(benchmark2.raw_data[m_time][0]) == benchmark2._args.num_steps
-
-    # Strict determinism check: compare per-step loss when strict mode + cuBLAS determinism are enabled
-    m_loss = 'fp32_train_loss'
-    assert m_loss in benchmark1.raw_data and m_loss in benchmark2.raw_data
-    a1 = np.array(benchmark1.raw_data[m_loss][0], dtype=float)
-    a2 = np.array(benchmark2.raw_data[m_loss][0], dtype=float)
-    # Require numeric (finite) values and exact equality
-    assert np.isfinite(a1).all() and np.isfinite(a2).all()
-    assert np.array_equal(a1, a2)
-
-
-@decorator.cuda_test
-@decorator.pytorch_test
-def test_pytorch_llama_non_deterministic_training():
-    """Test pytorch-llama2-7b benchmark with non-deterministic training (default behavior)."""
-    # Test that non-deterministic training works as expected
 
     context = BenchmarkRegistry.create_benchmark_context(
-        'llama2-7b',
-        platform=Platform.CUDA,
-        parameters='--hidden_size 256 --num_hidden_layers 2 --num_attention_heads 4 --num_key_value_heads 4 --intermediate_size 1024 --batch_size 1 --seq_len 32 --num_warmup 1 --num_steps 2 --precision float16 --model_action train',
-        framework=Framework.PYTORCH
+        'llama2-7b', platform=Platform.CUDA, parameters=parameters, framework=Framework.PYTORCH
     )
     benchmark = BenchmarkRegistry.launch_benchmark(context)
-    # Check that deterministic is disabled by default
-    assert (benchmark._args.deterministic == False)
-    assert (benchmark._args.random_seed == 42)  # Default value
 
+    assert benchmark and benchmark.return_code == ReturnCode.SUCCESS
+
+    # Expect one checksum log at step 100 (cadence = 100)
+    messages = [rec.getMessage() for rec in caplog.records if rec.name == 'superbench']
+    assert any('Checksum at step 100:' in m for m in messages)
 
 @decorator.cuda_test
 @decorator.pytorch_test
@@ -172,30 +128,70 @@ def test_pytorch_llama_soft_determinism():
     assert np.isfinite(a1).all() and np.isfinite(a2).all()
     assert np.allclose(a1, a2, rtol=1e-6, atol=1e-7)
 
-
 @decorator.cuda_test
 @decorator.pytorch_test
-def test_pytorch_llama_periodic_checksum_logging(caplog):
-    """Emit checksum log at the periodic cadence when deterministic training is enabled."""
-    # Ensure strict mode is off; only periodic checksum gated by deterministic should run
-    os.environ.pop('SB_STRICT_DETERMINISM', None)
-    os.environ.pop('CUBLAS_WORKSPACE_CONFIG', None)
+def test_pytorch_llama_strict_deterministic_training():
+    """Strict determinism: exact per-step loss equality under strict envs.
 
-    caplog.set_level(logging.INFO, logger='superbench')
+    This test verifies the strongest reproducibility guarantee: with strict determinism
+    enabled and a fixed seed, two runs must produce identical fp32 per-step training
+    losses (bitwise equality).
 
-    parameters = (
-        '--hidden_size 128 --num_hidden_layers 2 --num_attention_heads 4 --num_key_value_heads 4 '
-        '--intermediate_size 512 --batch_size 1 --seq_len 16 --num_warmup 1 --num_steps 100 '
-        '--precision float32 --sample_count 2 --deterministic --random_seed 42 --model_action train'
-    )
+    Requirements and behavior:
+    - Environment must be set before CUDA init: SB_STRICT_DETERMINISM=1 and
+        CUBLAS_WORKSPACE_CONFIG (":4096:8" or ":16:8").
+    - If these envs are not present, the test is skipped to avoid false failures.
+    - The benchmark is invoked with --deterministic and --random_seed 42.
+    - We compare the raw_data metric 'fp32_train_loss' via np.array_equal.
 
+    Rationale:
+    - Strict mode enforces deterministic kernels (warn_only=False) and will error if any
+        nondeterministic op is used, ensuring reproducible numerics beyond soft determinism.
+    """
+
+    parameters = '--hidden_size 256 --num_hidden_layers 2 --num_attention_heads 4 --num_key_value_heads 4 --intermediate_size 1024 --batch_size 1 --seq_len 32 --num_warmup 1 --num_steps 2 --precision float32 --sample_count 2 --deterministic --random_seed 42 --model_action train'
+    # Run twice with the same seed and deterministic flag using the registry
     context = BenchmarkRegistry.create_benchmark_context(
-        'llama2-7b', platform=Platform.CUDA, parameters=parameters, framework=Framework.PYTORCH
+        'llama2-7b',
+        platform=Platform.CUDA,
+        parameters=parameters,
+        framework=Framework.PYTORCH
     )
-    benchmark = BenchmarkRegistry.launch_benchmark(context)
+    benchmark1 = BenchmarkRegistry.launch_benchmark(context)
 
-    assert benchmark and benchmark.return_code == ReturnCode.SUCCESS
+    context2 = BenchmarkRegistry.create_benchmark_context(
+        'llama2-7b',
+        platform=Platform.CUDA,
+        parameters=parameters,
+        framework=Framework.PYTORCH
+    )
+    benchmark2 = BenchmarkRegistry.launch_benchmark(context2)
 
-    # Expect one checksum log at step 100 (cadence = 100)
-    messages = [rec.getMessage() for rec in caplog.records if rec.name == 'superbench']
-    assert any('Checksum at step 100:' in m for m in messages)
+    # Check that the run succeeded (basic checks)
+    assert (benchmark1)
+    assert (benchmark2)
+    assert (isinstance(benchmark1, PytorchLlama))
+    assert (isinstance(benchmark2, PytorchLlama))
+    assert (benchmark1._args.deterministic == True)
+    assert (benchmark2._args.deterministic == True)
+    assert (benchmark1._args.random_seed == 42)
+    assert (benchmark2._args.random_seed == 42)
+
+    # Validate time metrics exist and shapes are correct (but don't require equality due to scheduler/async noise)
+    m_time = 'fp32_train_step_time'
+    assert m_time in benchmark1.raw_data and m_time in benchmark2.raw_data
+    assert len(benchmark1.raw_data[m_time]) == benchmark1.run_count
+    assert len(benchmark2.raw_data[m_time]) == benchmark2.run_count
+    assert len(benchmark1.raw_data[m_time][0]) == benchmark1._args.num_steps
+    assert len(benchmark2.raw_data[m_time][0]) == benchmark2._args.num_steps
+
+    # Strict determinism check: compare per-step loss when strict mode + cuBLAS determinism are enabled
+    if os.environ.get('SB_STRICT_DETERMINISM') != '1' or 'CUBLAS_WORKSPACE_CONFIG' not in os.environ:
+        pytest.skip('Strict determinism env not set; skipping exact-equality check.')
+    m_loss = 'fp32_train_loss'
+    assert m_loss in benchmark1.raw_data and m_loss in benchmark2.raw_data
+    a1 = np.array(benchmark1.raw_data[m_loss][0], dtype=float)
+    a2 = np.array(benchmark2.raw_data[m_loss][0], dtype=float)
+    # Require numeric (finite) values and exact equality
+    assert np.isfinite(a1).all() and np.isfinite(a2).all()
+    assert np.array_equal(a1, a2)

--- a/tests/benchmarks/model_benchmarks/test_pytorch_llama.py
+++ b/tests/benchmarks/model_benchmarks/test_pytorch_llama.py
@@ -122,7 +122,7 @@ def test_pytorch_llama_non_deterministic_training():
     context = BenchmarkRegistry.create_benchmark_context(
         'llama2-7b',
         platform=Platform.CUDA,
-    parameters='--hidden_size 256 --num_hidden_layers 2 --num_attention_heads 4 --num_key_value_heads 4 --intermediate_size 1024 --batch_size 1 --seq_len 32 --num_warmup 1 --num_steps 2 --precision float16 --model_action train',
+        parameters='--hidden_size 256 --num_hidden_layers 2 --num_attention_heads 4 --num_key_value_heads 4 --intermediate_size 1024 --batch_size 1 --seq_len 32 --num_warmup 1 --num_steps 2 --precision float16 --model_action train',
         framework=Framework.PYTORCH
     )
     benchmark = BenchmarkRegistry.launch_benchmark(context)

--- a/tests/benchmarks/model_benchmarks/test_pytorch_llama.py
+++ b/tests/benchmarks/model_benchmarks/test_pytorch_llama.py
@@ -3,9 +3,12 @@
 
 """Tests for Llama model benchmarks."""
 
+import os
 import torch
+import numpy as np
+import logging
 from tests.helper import decorator
-from superbench.benchmarks import BenchmarkRegistry, Platform, Framework, BenchmarkType, ReturnCode
+from superbench.benchmarks import BenchmarkRegistry, Platform, Framework, BenchmarkType, ReturnCode, Precision
 from superbench.benchmarks.model_benchmarks.pytorch_llama import PytorchLlama
 
 
@@ -63,38 +66,51 @@ def test_pytorch_llama_7b():
 def test_pytorch_llama_deterministic_training():
     """Test pytorch-llama2-7b benchmark with deterministic training enabled."""
     # Test that deterministic training parameters work and don't cause crashes
+
+    parameters = '--hidden_size 256 --num_hidden_layers 2 --num_attention_heads 4 --num_key_value_heads 4 --intermediate_size 1024 --batch_size 1 --seq_len 32 --num_warmup 1 --num_steps 2 --precision float32 --sample_count 2 --deterministic --random_seed 42 --model_action train'
+    # Run twice with the same seed and deterministic flag using the registry
     context = BenchmarkRegistry.create_benchmark_context(
         'llama2-7b',
         platform=Platform.CUDA,
-        parameters='--batch_size 1 --seq_len 32 --num_warmup 1 --num_steps 2 --precision float16 \
-            --model_action train --deterministic --random_seed 42',
+        parameters=parameters,
         framework=Framework.PYTORCH
     )
+    benchmark1 = BenchmarkRegistry.launch_benchmark(context)
 
-    assert (BenchmarkRegistry.is_benchmark_context_valid(context))
+    context2 = BenchmarkRegistry.create_benchmark_context(
+        'llama2-7b',
+        platform=Platform.CUDA,
+        parameters=parameters,
+        framework=Framework.PYTORCH
+    )
+    benchmark2 = BenchmarkRegistry.launch_benchmark(context2)
 
-    # Run benchmark with deterministic settings
-    benchmark = BenchmarkRegistry.launch_benchmark(context)
+    # Check that the run succeeded (basic checks)
+    assert (benchmark1)
+    assert (benchmark2)
+    assert (isinstance(benchmark1, PytorchLlama))
+    assert (isinstance(benchmark2, PytorchLlama))
+    assert (benchmark1._args.deterministic == True)
+    assert (benchmark2._args.deterministic == True)
+    assert (benchmark1._args.random_seed == 42)
+    assert (benchmark2._args.random_seed == 42)
 
-    # Check that the run succeeded
-    assert (benchmark.return_code == ReturnCode.SUCCESS)
+    # Validate time metrics exist and shapes are correct (but don't require equality due to scheduler/async noise)
+    m_time = 'fp32_train_step_time'
+    assert m_time in benchmark1.raw_data and m_time in benchmark2.raw_data
+    assert len(benchmark1.raw_data[m_time]) == benchmark1.run_count
+    assert len(benchmark2.raw_data[m_time]) == benchmark2.run_count
+    assert len(benchmark1.raw_data[m_time][0]) == benchmark1._args.num_steps
+    assert len(benchmark2.raw_data[m_time][0]) == benchmark2._args.num_steps
 
-    # Check that deterministic parameters are set correctly
-    assert (benchmark._args.deterministic == True)
-    assert (benchmark._args.random_seed == 42)
-
-    # Check that we have valid results (deterministic training should still produce results)
-    assert 'fp16_train_step_time' in benchmark.result
-    assert len(benchmark.result['fp16_train_step_time']) > 0
-    assert all(isinstance(x, (int, float)) and x > 0 for x in benchmark.result['fp16_train_step_time'])
-
-    # Check that throughput results are also valid
-    if 'fp16_train_throughput' in benchmark.result:
-        assert len(benchmark.result['fp16_train_throughput']) > 0
-        assert all(isinstance(x, (int, float)) and x > 0 for x in benchmark.result['fp16_train_throughput'])
-
-    # Verify that the benchmark completes without errors when deterministic mode is enabled
-    # (This validates that our _enable_deterministic_training method works without crashes)
+    # Strict determinism check: compare per-step loss when strict mode + cuBLAS determinism are enabled
+    m_loss = 'fp32_train_loss'
+    assert m_loss in benchmark1.raw_data and m_loss in benchmark2.raw_data
+    a1 = np.array(benchmark1.raw_data[m_loss][0], dtype=float)
+    a2 = np.array(benchmark2.raw_data[m_loss][0], dtype=float)
+    # Require numeric (finite) values and exact equality
+    assert np.isfinite(a1).all() and np.isfinite(a2).all()
+    assert np.array_equal(a1, a2)
 
 
 @decorator.cuda_test
@@ -102,21 +118,14 @@ def test_pytorch_llama_deterministic_training():
 def test_pytorch_llama_non_deterministic_training():
     """Test pytorch-llama2-7b benchmark with non-deterministic training (default behavior)."""
     # Test that non-deterministic training works as expected
+
     context = BenchmarkRegistry.create_benchmark_context(
         'llama2-7b',
         platform=Platform.CUDA,
-        parameters='--batch_size 1 --seq_len 32 --num_warmup 1 --num_steps 2 --precision float16 \
-            --model_action train',
+    parameters='--hidden_size 256 --num_hidden_layers 2 --num_attention_heads 4 --num_key_value_heads 4 --intermediate_size 1024 --batch_size 1 --seq_len 32 --num_warmup 1 --num_steps 2 --precision float16 --model_action train',
         framework=Framework.PYTORCH
     )
-
-    assert (BenchmarkRegistry.is_benchmark_context_valid(context))
-
     benchmark = BenchmarkRegistry.launch_benchmark(context)
-
-    # Check that benchmark runs successfully
-    assert (benchmark.return_code == ReturnCode.SUCCESS)
-
     # Check that deterministic is disabled by default
     assert (benchmark._args.deterministic == False)
     assert (benchmark._args.random_seed == 42)  # Default value
@@ -124,30 +133,69 @@ def test_pytorch_llama_non_deterministic_training():
 
 @decorator.cuda_test
 @decorator.pytorch_test
-def test_pytorch_llama_deterministic_parameters():
-    """Test pytorch-llama2-7b benchmark parameter parsing for deterministic training."""
-    # Test parameter parsing for deterministic training
-    context = BenchmarkRegistry.create_benchmark_context(
-        'llama2-7b',
-        platform=Platform.CUDA,
-        parameters='--batch_size 1 --seq_len 32 --num_warmup 1 --num_steps 2 --precision float16 \
-            --model_action train --deterministic --random_seed 123',
-        framework=Framework.PYTORCH
+def test_pytorch_llama_soft_determinism():
+    """Test soft determinism: deterministic=True without strict envs should yield repeatable numeric results."""
+    # Ensure strict determinism is disabled within this test
+    os.environ.pop('SB_STRICT_DETERMINISM', None)
+    os.environ.pop('CUBLAS_WORKSPACE_CONFIG', None)
+
+    parameters = (
+        '--hidden_size 256 --num_hidden_layers 2 --num_attention_heads 4 --num_key_value_heads 4 '
+        '--intermediate_size 1024 --batch_size 1 --seq_len 32 --num_warmup 1 --num_steps 2 '
+        '--precision float32 --sample_count 2 --deterministic --random_seed 42 --model_action train'
     )
 
-    assert (BenchmarkRegistry.is_benchmark_context_valid(context))
+    context = BenchmarkRegistry.create_benchmark_context(
+        'llama2-7b', platform=Platform.CUDA, parameters=parameters, framework=Framework.PYTORCH
+    )
+    b1 = BenchmarkRegistry.launch_benchmark(context)
 
+    context2 = BenchmarkRegistry.create_benchmark_context(
+        'llama2-7b', platform=Platform.CUDA, parameters=parameters, framework=Framework.PYTORCH
+    )
+    b2 = BenchmarkRegistry.launch_benchmark(context2)
+
+    assert b1 and b2
+    assert b1._args.deterministic and b2._args.deterministic
+
+    # Check time metric shapes
+    m_time = 'fp32_train_step_time'
+    assert m_time in b1.raw_data and m_time in b2.raw_data
+    assert len(b1.raw_data[m_time][0]) == b1._args.num_steps
+    assert len(b2.raw_data[m_time][0]) == b2._args.num_steps
+
+    # Compare per-step loss for closeness (soft determinism: allow tiny numeric diffs)
+    m_loss = 'fp32_train_loss'
+    assert m_loss in b1.raw_data and m_loss in b2.raw_data
+    a1 = np.array(b1.raw_data[m_loss][0], dtype=float)
+    a2 = np.array(b2.raw_data[m_loss][0], dtype=float)
+    assert np.isfinite(a1).all() and np.isfinite(a2).all()
+    assert np.allclose(a1, a2, rtol=1e-6, atol=1e-7)
+
+
+@decorator.cuda_test
+@decorator.pytorch_test
+def test_pytorch_llama_periodic_checksum_logging(caplog):
+    """Emit checksum log at the periodic cadence when deterministic training is enabled."""
+    # Ensure strict mode is off; only periodic checksum gated by deterministic should run
+    os.environ.pop('SB_STRICT_DETERMINISM', None)
+    os.environ.pop('CUBLAS_WORKSPACE_CONFIG', None)
+
+    caplog.set_level(logging.INFO, logger='superbench')
+
+    parameters = (
+        '--hidden_size 128 --num_hidden_layers 2 --num_attention_heads 4 --num_key_value_heads 4 '
+        '--intermediate_size 512 --batch_size 1 --seq_len 16 --num_warmup 1 --num_steps 100 '
+        '--precision float32 --sample_count 2 --deterministic --random_seed 42 --model_action train'
+    )
+
+    context = BenchmarkRegistry.create_benchmark_context(
+        'llama2-7b', platform=Platform.CUDA, parameters=parameters, framework=Framework.PYTORCH
+    )
     benchmark = BenchmarkRegistry.launch_benchmark(context)
 
-    # Check basic functionality
-    assert (benchmark.return_code == ReturnCode.SUCCESS)
+    assert benchmark and benchmark.return_code == ReturnCode.SUCCESS
 
-    # Check that parameters are parsed correctly
-    assert (benchmark._args.deterministic == True)
-    assert (benchmark._args.random_seed == 123)
-
-    # Check that all other parameters are still working
-    assert (benchmark._args.batch_size == 1)
-    assert (benchmark._args.seq_len == 32)
-    assert (benchmark._args.num_warmup == 1)
-    assert (benchmark._args.num_steps == 2)
+    # Expect one checksum log at step 100 (cadence = 100)
+    messages = [rec.getMessage() for rec in caplog.records if rec.name == 'superbench']
+    assert any('Checksum at step 100:' in m for m in messages)

--- a/tests/benchmarks/model_benchmarks/test_pytorch_lstm.py
+++ b/tests/benchmarks/model_benchmarks/test_pytorch_lstm.py
@@ -3,6 +3,10 @@
 
 """Tests for LSTM model benchmarks."""
 
+import os
+import logging
+import numpy as np
+
 from tests.helper import decorator
 from superbench.benchmarks import BenchmarkRegistry, Platform, Framework, BenchmarkType, ReturnCode
 from superbench.benchmarks.model_benchmarks.pytorch_lstm import PytorchLSTM
@@ -73,3 +77,86 @@ def run_pytorch_lstm(parameters='', check_metrics=[]):
         assert (len(benchmark.raw_data[metric]) == benchmark.run_count)
         assert (len(benchmark.raw_data[metric][0]) == benchmark._args.num_steps)
         assert (len(benchmark.result[metric]) == benchmark.run_count)
+
+
+@decorator.cuda_test
+@decorator.pytorch_test
+def test_pytorch_lstm_periodic_checksum_logging(caplog):
+    """Emit checksum log at the periodic cadence when deterministic training is enabled."""
+    os.environ.pop('SB_STRICT_DETERMINISM', None)
+    os.environ.pop('CUBLAS_WORKSPACE_CONFIG', None)
+
+    caplog.set_level(logging.INFO, logger='superbench')
+
+    parameters = (
+        '--batch_size 1 --num_classes 5 --seq_len 8 --num_warmup 1 --num_steps 100 '
+        '--precision float32 --deterministic --random_seed 42 --model_action train'
+    )
+
+    context = BenchmarkRegistry.create_benchmark_context(
+        'lstm', platform=Platform.CUDA, parameters=parameters, framework=Framework.PYTORCH
+    )
+    benchmark = BenchmarkRegistry.launch_benchmark(context)
+
+    assert benchmark and benchmark.return_code == ReturnCode.SUCCESS
+
+    messages = [rec.getMessage() for rec in caplog.records if rec.name == 'superbench']
+    assert any('Checksum at step 100:' in m for m in messages)
+
+
+@decorator.cuda_test
+@decorator.pytorch_test
+def test_pytorch_lstm_soft_determinism():
+    os.environ.pop('SB_STRICT_DETERMINISM', None)
+    os.environ.pop('CUBLAS_WORKSPACE_CONFIG', None)
+    params = (
+        '--batch_size 1 --num_classes 5 --seq_len 8 --num_warmup 1 --num_steps 2 '
+        '--precision float32 --deterministic --random_seed 42 --model_action train'
+    )
+    ctx1 = BenchmarkRegistry.create_benchmark_context('lstm', platform=Platform.CUDA, parameters=params, framework=Framework.PYTORCH)
+    b1 = BenchmarkRegistry.launch_benchmark(ctx1)
+    ctx2 = BenchmarkRegistry.create_benchmark_context('lstm', platform=Platform.CUDA, parameters=params, framework=Framework.PYTORCH)
+    b2 = BenchmarkRegistry.launch_benchmark(ctx2)
+    assert b1 and b2 and b1.return_code == ReturnCode.SUCCESS and b2.return_code == ReturnCode.SUCCESS
+    m_loss = 'fp32_train_loss'
+    a1 = np.array(b1.raw_data[m_loss][0], dtype=float)
+    a2 = np.array(b2.raw_data[m_loss][0], dtype=float)
+    assert np.isfinite(a1).all() and np.isfinite(a2).all()
+    assert np.allclose(a1, a2, rtol=1e-6, atol=1e-7)
+
+
+@decorator.cuda_test
+@decorator.pytorch_test
+def test_pytorch_lstm_strict_determinism():
+    # Rely on deterministic flag and seed; assert exact equality
+    params = (
+        '--batch_size 1 --num_classes 5 --seq_len 8 --num_warmup 1 --num_steps 2 '
+        '--precision float32 --deterministic --random_seed 42 --model_action train'
+    )
+    ctx1 = BenchmarkRegistry.create_benchmark_context('lstm', platform=Platform.CUDA, parameters=params, framework=Framework.PYTORCH)
+    b1 = BenchmarkRegistry.launch_benchmark(ctx1)
+    ctx2 = BenchmarkRegistry.create_benchmark_context('lstm', platform=Platform.CUDA, parameters=params, framework=Framework.PYTORCH)
+    b2 = BenchmarkRegistry.launch_benchmark(ctx2)
+    assert b1 and b2 and b1.return_code == ReturnCode.SUCCESS and b2.return_code == ReturnCode.SUCCESS
+    m_loss = 'fp32_train_loss'
+    a1 = np.array(b1.raw_data[m_loss][0], dtype=float)
+    a2 = np.array(b2.raw_data[m_loss][0], dtype=float)
+    assert np.isfinite(a1).all() and np.isfinite(a2).all()
+    assert np.array_equal(a1, a2)
+
+
+@decorator.cuda_test
+@decorator.pytorch_test
+def test_pytorch_lstm_non_deterministic_training():
+    """Test that non-deterministic training is the default when not specified."""
+    context = BenchmarkRegistry.create_benchmark_context(
+        'lstm',
+        platform=Platform.CUDA,
+        parameters='--batch_size 1 --num_classes 5 --seq_len 8 --num_warmup 1 --num_steps 2 --precision float16 --model_action train',
+        framework=Framework.PYTORCH
+    )
+    benchmark = BenchmarkRegistry.launch_benchmark(context)
+    assert benchmark and benchmark.return_code == ReturnCode.SUCCESS
+    assert benchmark._args.deterministic == False
+    # default seed set by benchmark args
+    assert benchmark._args.random_seed == 42

--- a/tests/benchmarks/model_benchmarks/test_pytorch_lstm.py
+++ b/tests/benchmarks/model_benchmarks/test_pytorch_lstm.py
@@ -82,8 +82,8 @@ def run_pytorch_lstm(parameters='', check_metrics=[]):
 
 @decorator.cuda_test
 @decorator.pytorch_test
-def test_pytorch_lstm_periodic_checksum_logging(caplog):
-    """Emit checksum log at the periodic cadence when deterministic training is enabled."""
+def test_pytorch_lstm_periodic_fingerprint_logging(caplog):
+    """Emit Loss and ActMean logs at the periodic cadence under deterministic training."""
     os.environ.pop('SB_STRICT_DETERMINISM', None)
     os.environ.pop('CUBLAS_WORKSPACE_CONFIG', None)
 
@@ -102,7 +102,8 @@ def test_pytorch_lstm_periodic_checksum_logging(caplog):
     assert benchmark and benchmark.return_code == ReturnCode.SUCCESS
 
     messages = [rec.getMessage() for rec in caplog.records if rec.name == 'superbench']
-    assert any('Checksum at step 100:' in m for m in messages)
+    assert any('Loss at step 100:' in m for m in messages)
+    assert any('ActMean at step 100:' in m for m in messages)
 
 
 @decorator.cuda_test

--- a/tests/benchmarks/model_benchmarks/test_pytorch_mixtral.py
+++ b/tests/benchmarks/model_benchmarks/test_pytorch_mixtral.py
@@ -73,8 +73,8 @@ def test_pytorch_mixtral_8x7b():
 
 @decorator.cuda_test
 @decorator.pytorch_test
-def test_pytorch_mixtral_periodic_checksum_logging(caplog):
-    """Emit checksum log at the periodic cadence when deterministic training is enabled."""
+def test_pytorch_mixtral_periodic_fingerprint_logging(caplog):
+    """Emit Loss and ActMean logs at the periodic cadence under deterministic training."""
     if sys.version_info < (3, 8):
         return
     os.environ.pop('SB_STRICT_DETERMINISM', None)
@@ -96,7 +96,8 @@ def test_pytorch_mixtral_periodic_checksum_logging(caplog):
     assert benchmark and benchmark.return_code == ReturnCode.SUCCESS
 
     messages = [rec.getMessage() for rec in caplog.records if rec.name == 'superbench']
-    assert any('Checksum at step 100:' in m for m in messages)
+    assert any('Loss at step 100:' in m for m in messages)
+    assert any('ActMean at step 100:' in m for m in messages)
 
 
 @decorator.cuda_test


### PR DESCRIPTION
### Deterministic training verification across PyTorch benchmarks

**Summary** 
Introduce a consistent, low-overhead determinism verification across BERT, GPT-2, Llama, CNN, LSTM, and Mixtral to help detect potential silent data corruption (SDC) and ensure run-to-run reproducibility. Deterministic runs emit lightweight “Loss + ActMean” fingerprints for periodic validation.

**Determinism modes**
1. Soft: torch.use_deterministic_algorithms(True, warn_only=True); compare per-step fp32 losses across runs via numpy.allclose.
2. Strict: SB_STRICT_DETERMINISM=1 → torch.use_deterministic_algorithms(warn_only=False); requires 3CUBLAS_WORKSPACE_CONFIG=:4096:8 (or :16:8); compare per-step fp32 losses via numpy.array_equal (tests skip if envs not set).

**Controls**
1.Args: --deterministic, --random_seed (example scripts also support --strict_determinism).
2.Env: SB_STRICT_DETERMINISM=1, CUBLAS_WORKSPACE_CONFIG set.

**Implementation**
1. Periodic fingerprints during deterministic runs:
Log every 100 steps: “Loss at step N: …” and “ActMean at step N: …”.
2. Record per-step fp32 training loss arrays in raw results for comparison.

**Tests and logs**
1. Fingerprint tests assert presence of “Loss/ActMean at step 100” when num_steps ≥ 100.
2. Soft determinism tests: assert numpy.allclose on per-step fp32 loss arrays.
3. Strict determinism tests: assert numpy.array_equal when required envs are set; otherwise skipped.
4. Log assertions updated to the new fingerprint keys.

**Notes**
Set strict env vars before the run to fully enforce determinism.