### PR TITLE
Benchmarks: ib validation - add --set_ib_devices option to auto-select IB device by MPI local rank

### DIFF
--- a/superbench/benchmarks/micro_benchmarks/ib_validation_performance.py
+++ b/superbench/benchmarks/micro_benchmarks/ib_validation_performance.py
@@ -10,6 +10,7 @@ from superbench.common.utils import gen_pair_wise_config, gen_topo_aware_config
 from superbench.benchmarks import BenchmarkRegistry, ReturnCode
 from superbench.common.devices import GPU
 from superbench.benchmarks.micro_benchmarks import MicroBenchmarkWithInvoke
+from superbench.common.utils import network
 
 
 class IBBenchmark(MicroBenchmarkWithInvoke):
@@ -42,6 +43,12 @@ class IBBenchmark(MicroBenchmarkWithInvoke):
             default='mlx5_0',
             required=False,
             help='The IB device, e.g., mlx5_0, mlx5_$LOCAL_RANK, mlx5_$((LOCAL_RANK/2)), etc.',
+        )
+        self._parser.add_argument(
+            '--set_ib_devices',
+            action='store_true',
+            default=False,
+            help='Set irregular IB devices automatically according to the local rank when running with MPI. If IB devices are not able to scan, please use env IB_DEVICES to set them manually.',
         )
         self._parser.add_argument(
             '--gpu_dev',
@@ -282,6 +289,16 @@ class IBBenchmark(MicroBenchmarkWithInvoke):
                 return False
         # Generate ib command params
         command_params = f'-F -n {self._args.iters} -d {self._args.ib_dev} {msg_size} {gpu_dev}'
+        if self._args.set_ib_devices:
+            ib_devices = network.get_ib_devices()
+            local_rank = int(os.getenv('OMPI_COMM_WORLD_LOCAL_RANK', 0))
+            if local_rank >= len(ib_devices):
+                self._result.set_return_code(ReturnCode.INVALID_ARGUMENT)
+                logger.error(
+                    f"Local rank {local_rank} exceeds available IB devices ({len(ib_devices)}) - benchmark: {self._name}"
+                )
+                return False
+            command_params = f"-F -n {self._args.iters} -d {ib_devices[local_rank].split(':')[0]} {msg_size} {gpu_dev}"
         command_params = f'{command_params.strip()} --report_gbits'
         return command_params
 

--- a/superbench/common/utils/network.py
+++ b/superbench/common/utils/network.py
@@ -5,6 +5,7 @@
 
 import socket
 import re
+import os
 from pathlib import Path
 
 
@@ -31,6 +32,8 @@ def get_ib_devices():
     Return:
         ib_devices_port (list): IB devices with available ports in current system.
     """
+    if os.getenv('IB_DEVICES', None):
+        return os.getenv('IB_DEVICES').split(',')
     devices = list(p.name for p in Path('/sys/class/infiniband').glob('*'))
     ib_devices_port_dict = {}
     for device in devices:


### PR DESCRIPTION
**Description**
Summary:


**Major Revision**
- Add a new CLI flag --set_ib_devices to automatically select irregular IB devices based on the MPI local rank.
- When enabled, the benchmark queries available IB devices via network.get_ib_devices() and selects the device corresponding to OMPI_COMM_WORLD_LOCAL_RANK.
- Fall back to existing --ib_dev behavior when the flag is not provided.

**Minor Revision**
- Add an env in network.get_ib_devices() to allow user to set the device name
