### PR TITLE
Benchmark: Model benchmark - add option to exclude data copy time in model benchmarks

### DIFF
--- a/superbench/benchmarks/model_benchmarks/model_base.py
+++ b/superbench/benchmarks/model_benchmarks/model_base.py
@@ -151,7 +151,7 @@ class ModelBenchmark(Benchmark):
             '--no_copy',
             action='store_true',
             default=False,
-            help='Enable option to exclude data copy time.',
+            help='Exclude GPU data copy time from benchmark measurements.',
         )
 
     @abstractmethod

--- a/superbench/benchmarks/model_benchmarks/model_base.py
+++ b/superbench/benchmarks/model_benchmarks/model_base.py
@@ -148,10 +148,10 @@ class ModelBenchmark(Benchmark):
         )
 
         self._parser.add_argument(
-            '--no_copy',
+            '--exclude_copy_time',
             action='store_true',
             default=False,
-            help='Exclude GPU data copy time from benchmark measurements.',
+            help='Exclude GPU data copy time from measured time.',
         )
 
     @abstractmethod

--- a/superbench/benchmarks/model_benchmarks/model_base.py
+++ b/superbench/benchmarks/model_benchmarks/model_base.py
@@ -147,6 +147,13 @@ class ModelBenchmark(Benchmark):
             help='Real-time log every n steps.',
         )
 
+        self._parser.add_argument(
+            '--no_copy',
+            action='store_true',
+            default=False,
+            help='Enable option to exclude data copy time.',
+        )
+
     @abstractmethod
     def _judge_gpu_availability(self):
         """Judge GPUs' availability according to arguments and running environment."""

--- a/superbench/benchmarks/model_benchmarks/pytorch_bert.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_bert.py
@@ -213,6 +213,8 @@ class PytorchBERT(PytorchBase):
                     start = self._timer()
                     if self._gpu_available:
                         sample = sample.cuda()
+                    if self._args.no_copy:
+                        start = self._timer()
                     if self._fp8_recipe is not None:
                         with te.fp8_autocast(enabled=True, fp8_recipe=self._fp8_recipe):
                             self._model(sample)

--- a/superbench/benchmarks/model_benchmarks/pytorch_bert.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_bert.py
@@ -174,7 +174,7 @@ class PytorchBERT(PytorchBase):
                 start = self._timer()
                 if self._gpu_available:
                     sample = sample.cuda()
-                if self._args.no_copy:
+                if self._args.exclude_copy_time:
                     start = self._timer()
                 self._optimizer.zero_grad()
                 if self._fp8_recipe is not None:
@@ -213,7 +213,7 @@ class PytorchBERT(PytorchBase):
                     start = self._timer()
                     if self._gpu_available:
                         sample = sample.cuda()
-                    if self._args.no_copy:
+                    if self._args.exclude_copy_time:
                         start = self._timer()
                     if self._fp8_recipe is not None:
                         with te.fp8_autocast(enabled=True, fp8_recipe=self._fp8_recipe):

--- a/superbench/benchmarks/model_benchmarks/pytorch_bert.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_bert.py
@@ -174,6 +174,8 @@ class PytorchBERT(PytorchBase):
                 start = self._timer()
                 if self._gpu_available:
                     sample = sample.cuda()
+                if self._args.no_copy:
+                    start = self._timer()
                 self._optimizer.zero_grad()
                 if self._fp8_recipe is not None:
                     with te.fp8_autocast(enabled=True, fp8_recipe=self._fp8_recipe):

--- a/superbench/benchmarks/model_benchmarks/pytorch_cnn.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_cnn.py
@@ -140,6 +140,8 @@ class PytorchCNN(PytorchBase):
                     start = self._timer()
                     if self._gpu_available:
                         sample = sample.cuda()
+                    if self._args.no_copy:
+                        start = self._timer()
                     self._model(sample)
                     end = self._timer()
                     curr_step += 1

--- a/superbench/benchmarks/model_benchmarks/pytorch_cnn.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_cnn.py
@@ -104,7 +104,7 @@ class PytorchCNN(PytorchBase):
                 start = self._timer()
                 if self._gpu_available:
                     sample = sample.cuda()
-                if self._args.no_copy:
+                if self._args.exclude_copy_time:
                     start = self._timer()
                 self._optimizer.zero_grad()
                 output = self._model(sample)
@@ -140,7 +140,7 @@ class PytorchCNN(PytorchBase):
                     start = self._timer()
                     if self._gpu_available:
                         sample = sample.cuda()
-                    if self._args.no_copy:
+                    if self._args.exclude_copy_time:
                         start = self._timer()
                     self._model(sample)
                     end = self._timer()

--- a/superbench/benchmarks/model_benchmarks/pytorch_cnn.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_cnn.py
@@ -104,6 +104,8 @@ class PytorchCNN(PytorchBase):
                 start = self._timer()
                 if self._gpu_available:
                     sample = sample.cuda()
+                if self._args.no_copy:
+                    start = self._timer()
                 self._optimizer.zero_grad()
                 output = self._model(sample)
                 loss = self._loss_fn(output, self._target)

--- a/superbench/benchmarks/model_benchmarks/pytorch_gpt2.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_gpt2.py
@@ -207,6 +207,8 @@ class PytorchGPT2(PytorchBase):
                     start = self._timer()
                     if self._gpu_available:
                         sample = sample.cuda()
+                    if self._args.no_copy:
+                        start = self._timer()
                     if self._fp8_recipe is not None:
                         with te.fp8_autocast(enabled=True, fp8_recipe=self._fp8_recipe):
                             self._model(sample)

--- a/superbench/benchmarks/model_benchmarks/pytorch_gpt2.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_gpt2.py
@@ -168,7 +168,7 @@ class PytorchGPT2(PytorchBase):
                 start = self._timer()
                 if self._gpu_available:
                     sample = sample.cuda()
-                if self._args.no_copy:
+                if self._args.exclude_copy_time:
                     start = self._timer()
                 self._optimizer.zero_grad()
                 if self._fp8_recipe is not None:
@@ -207,7 +207,7 @@ class PytorchGPT2(PytorchBase):
                     start = self._timer()
                     if self._gpu_available:
                         sample = sample.cuda()
-                    if self._args.no_copy:
+                    if self._args.exclude_copy_time:
                         start = self._timer()
                     if self._fp8_recipe is not None:
                         with te.fp8_autocast(enabled=True, fp8_recipe=self._fp8_recipe):

--- a/superbench/benchmarks/model_benchmarks/pytorch_gpt2.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_gpt2.py
@@ -168,6 +168,8 @@ class PytorchGPT2(PytorchBase):
                 start = self._timer()
                 if self._gpu_available:
                     sample = sample.cuda()
+                if self._args.no_copy:
+                    start = self._timer()
                 self._optimizer.zero_grad()
                 if self._fp8_recipe is not None:
                     with te.fp8_autocast(enabled=True, fp8_recipe=self._fp8_recipe):

--- a/superbench/benchmarks/model_benchmarks/pytorch_llama.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_llama.py
@@ -188,7 +188,7 @@ class PytorchLlama(PytorchBase):
                 start = self._timer()
                 if self._gpu_available:
                     sample = sample.cuda()
-                if self._args.no_copy:
+                if self._args.exclude_copy_time:
                     start = self._timer()
                 self._optimizer.zero_grad()
                 if self._fp8_recipe is not None:
@@ -227,7 +227,7 @@ class PytorchLlama(PytorchBase):
                     start = self._timer()
                     if self._gpu_available:
                         sample = sample.cuda()
-                    if self._args.no_copy:
+                    if self._args.exclude_copy_time:
                         start = self._timer()
                     if self._fp8_recipe is not None:
                         with te.fp8_autocast(enabled=True, fp8_recipe=self._fp8_recipe):

--- a/superbench/benchmarks/model_benchmarks/pytorch_llama.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_llama.py
@@ -225,6 +225,8 @@ class PytorchLlama(PytorchBase):
                     start = self._timer()
                     if self._gpu_available:
                         sample = sample.cuda()
+                    if self._args.no_copy:
+                        start = self._timer()
                     if self._fp8_recipe is not None:
                         with te.fp8_autocast(enabled=True, fp8_recipe=self._fp8_recipe):
                             self._model(sample)

--- a/superbench/benchmarks/model_benchmarks/pytorch_llama.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_llama.py
@@ -188,6 +188,8 @@ class PytorchLlama(PytorchBase):
                 start = self._timer()
                 if self._gpu_available:
                     sample = sample.cuda()
+                if self._args.no_copy:
+                    start = self._timer()
                 self._optimizer.zero_grad()
                 if self._fp8_recipe is not None:
                     with te.fp8_autocast(enabled=True, fp8_recipe=self._fp8_recipe):

--- a/superbench/benchmarks/model_benchmarks/pytorch_lstm.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_lstm.py
@@ -144,6 +144,8 @@ class PytorchLSTM(PytorchBase):
                 start = self._timer()
                 if self._gpu_available:
                     sample = sample.cuda()
+                if self._args.no_copy:
+                    start = self._timer()
                 self._optimizer.zero_grad()
                 output = self._model(sample)
                 loss = self._loss_fn(output, self._target)

--- a/superbench/benchmarks/model_benchmarks/pytorch_lstm.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_lstm.py
@@ -144,7 +144,7 @@ class PytorchLSTM(PytorchBase):
                 start = self._timer()
                 if self._gpu_available:
                     sample = sample.cuda()
-                if self._args.no_copy:
+                if self._args.exclude_copy_time:
                     start = self._timer()
                 self._optimizer.zero_grad()
                 output = self._model(sample)
@@ -180,7 +180,7 @@ class PytorchLSTM(PytorchBase):
                     start = self._timer()
                     if self._gpu_available:
                         sample = sample.cuda()
-                    if self._args.no_copy:
+                    if self._args.exclude_copy_time:
                         start = self._timer()
                     self._model(sample)
                     end = self._timer()

--- a/superbench/benchmarks/model_benchmarks/pytorch_lstm.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_lstm.py
@@ -180,6 +180,8 @@ class PytorchLSTM(PytorchBase):
                     start = self._timer()
                     if self._gpu_available:
                         sample = sample.cuda()
+                    if self._args.no_copy:
+                        start = self._timer()
                     self._model(sample)
                     end = self._timer()
                     curr_step += 1

--- a/superbench/benchmarks/model_benchmarks/pytorch_mixtral_impl.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_mixtral_impl.py
@@ -202,7 +202,7 @@ class PytorchMixtral(PytorchBase):
                 start = self._timer()
                 if self._gpu_available:
                     sample = sample.cuda()
-                if self._args.no_copy:
+                if self._args.exclude_copy_time:
                     start = self._timer()
                 self._optimizer.zero_grad()
                 if self._fp8_recipe is not None:
@@ -241,7 +241,7 @@ class PytorchMixtral(PytorchBase):
                     start = self._timer()
                     if self._gpu_available:
                         sample = sample.cuda()
-                    if self._args.no_copy:
+                    if self._args.exclude_copy_time:
                         start = self._timer()
                     if self._fp8_recipe is not None:
                         with te.fp8_autocast(enabled=True, fp8_recipe=self._fp8_recipe):

--- a/superbench/benchmarks/model_benchmarks/pytorch_mixtral_impl.py
+++ b/superbench/benchmarks/model_benchmarks/pytorch_mixtral_impl.py
@@ -202,6 +202,8 @@ class PytorchMixtral(PytorchBase):
                 start = self._timer()
                 if self._gpu_available:
                     sample = sample.cuda()
+                if self._args.no_copy:
+                    start = self._timer()
                 self._optimizer.zero_grad()
                 if self._fp8_recipe is not None:
                     with te.fp8_autocast(enabled=True, fp8_recipe=self._fp8_recipe):
@@ -239,6 +241,8 @@ class PytorchMixtral(PytorchBase):
                     start = self._timer()
                     if self._gpu_available:
                         sample = sample.cuda()
+                    if self._args.no_copy:
+                        start = self._timer()
                     if self._fp8_recipe is not None:
                         with te.fp8_autocast(enabled=True, fp8_recipe=self._fp8_recipe):
                             self._model(sample)

--- a/tests/benchmarks/model_benchmarks/test_model_base.py
+++ b/tests/benchmarks/model_benchmarks/test_model_base.py
@@ -165,6 +165,7 @@ def test_arguments_related_interfaces():
                         result object.
   --model_action ModelAction [ModelAction ...]
                         Benchmark model process. E.g. train inference.
+  --no_copy             Enable option to exclude data copy time.
   --no_gpu              Disable GPU training.
   --num_steps int       The number of test step.
   --num_warmup int      The number of warmup step.
@@ -205,6 +206,7 @@ def test_preprocess():
                         result object.
   --model_action ModelAction [ModelAction ...]
                         Benchmark model process. E.g. train inference.
+  --no_copy             Enable option to exclude data copy time.
   --no_gpu              Disable GPU training.
   --num_steps int       The number of test step.
   --num_warmup int      The number of warmup step.

--- a/tests/benchmarks/model_benchmarks/test_model_base.py
+++ b/tests/benchmarks/model_benchmarks/test_model_base.py
@@ -165,7 +165,7 @@ def test_arguments_related_interfaces():
                         result object.
   --model_action ModelAction [ModelAction ...]
                         Benchmark model process. E.g. train inference.
-  --no_copy             Enable option to exclude data copy time.
+  --exclude_copy_time   Exclude GPU data copy time from measured time.
   --no_gpu              Disable GPU training.
   --num_steps int       The number of test step.
   --num_warmup int      The number of warmup step.
@@ -206,7 +206,7 @@ def test_preprocess():
                         result object.
   --model_action ModelAction [ModelAction ...]
                         Benchmark model process. E.g. train inference.
-  --no_copy             Enable option to exclude data copy time.
+  --exclude_copy_time   Exclude GPU data copy time from measured time.
   --no_gpu              Disable GPU training.
   --num_steps int       The number of test step.
   --num_warmup int      The number of warmup step.

--- a/tests/benchmarks/model_benchmarks/test_model_base.py
+++ b/tests/benchmarks/model_benchmarks/test_model_base.py
@@ -157,6 +157,7 @@ def test_arguments_related_interfaces():
                         Distributed implementations. E.g. ddp mirrored
                         multiworkermirrored parameterserver horovod.
   --duration int        The elapsed time of benchmark in seconds.
+  --exclude_copy_time   Exclude GPU data copy time from measured time.
   --force_fp32          Enable option to use full float32 precision.
   --hidden_size int     Hidden size.
   --log_flushing        Real-time log flushing.
@@ -165,7 +166,6 @@ def test_arguments_related_interfaces():
                         result object.
   --model_action ModelAction [ModelAction ...]
                         Benchmark model process. E.g. train inference.
-  --exclude_copy_time   Exclude GPU data copy time from measured time.
   --no_gpu              Disable GPU training.
   --num_steps int       The number of test step.
   --num_warmup int      The number of warmup step.
@@ -198,6 +198,7 @@ def test_preprocess():
                         Distributed implementations. E.g. ddp mirrored
                         multiworkermirrored parameterserver horovod.
   --duration int        The elapsed time of benchmark in seconds.
+  --exclude_copy_time   Exclude GPU data copy time from measured time.
   --force_fp32          Enable option to use full float32 precision.
   --hidden_size int     Hidden size.
   --log_flushing        Real-time log flushing.
@@ -206,7 +207,6 @@ def test_preprocess():
                         result object.
   --model_action ModelAction [ModelAction ...]
                         Benchmark model process. E.g. train inference.
-  --exclude_copy_time   Exclude GPU data copy time from measured time.
   --no_gpu              Disable GPU training.
   --num_steps int       The number of test step.
   --num_warmup int      The number of warmup step.


### PR DESCRIPTION
**Description**
add option to exclude data copy time in model benchmarks.

**Major Revision**
- add an option --exclude_copy_time
- move start time after data copy finish in measured time