### PR TITLE
CI/CD - Fix python3.10 pipeline

### DIFF
--- a/.azure-pipelines/cpu-unit-test.yml
+++ b/.azure-pipelines/cpu-unit-test.yml
@@ -26,7 +26,7 @@ steps:
       echo "##vso[task.prependpath]$HOME/.local/bin"
     displayName: Export path
   - script: |
-      if [[ "$(imageTag)" < "3.11" ]]; then
+      if python3 -c "import sys; exit(0 if sys.version_info < (3, 11) else 1)"; then
         python3 -m pip install --upgrade pip setuptools==65.7
       else
         python3 -m pip install --upgrade pip


### PR DESCRIPTION
**Description**
Python3.10 pipeline failed.

**Solution**
From log, 'bc' cmd is missing. Since our image tags are simple, the solution is to remove 'bc' cmd directly.

