### PR TITLE
CI/CD - Fix Azure test pipeline

### DIFF
--- a/.azure-pipelines/cpu-unit-test.yml
+++ b/.azure-pipelines/cpu-unit-test.yml
@@ -27,11 +27,9 @@ steps:
     displayName: Export path
   - script: |
       if python3 -c "import sys; exit(0 if sys.version_info < (3, 11) else 1)"; then
-        python3 -m pip install --upgrade pip setuptools==65.7
-      else
-        python3 -m pip install --upgrade pip setuptools
+        python3 -m pip install --upgrade setuptools==65.7
       fi
-      python3 -m pip install --no-build-isolation .[test,cpuworker]
+      python3 -m pip install .[test,cpuworker]
       make postinstall
     displayName: Install dependencies
   - script: |

--- a/.azure-pipelines/cuda-unit-test.yml
+++ b/.azure-pipelines/cuda-unit-test.yml
@@ -24,8 +24,8 @@ steps:
         yes '' | apt-get install -y -q sudo && \
         apt-get install -y -q \
         ffmpeg libavcodec-dev libavformat-dev libavutil-dev libboost-program-options-dev libswresample-dev"
-      python3 -m pip install --upgrade pip setuptools==65.7
-      python3 -m pip install --no-build-isolation .[test,nvworker]
+      python3 -m pip install --upgrade setuptools==65.7
+      python3 -m pip install .[test,nvworker]
       make postinstall
     displayName: Install dependencies
   - script: |


### PR DESCRIPTION
Python3.10 verification pipeline failed for conflict 'setuptools' version as below.
<img width="1157" height="622" alt="image" src="https://github.com/user-attachments/assets/ba0f6045-4b92-4fd8-b92f-1c474725534c" />

Root Cause:
The problem is that modern pip (25.3) uses an isolated build environment with the latest setuptools by default. The pipeline installs setuptools 65.7 in the user environment, but pip builds the package in an isolated environment with newer setuptools, which conflicts with the version check in [setup.py].

Solution:
Remove pip upgrade.