### PR TITLE
Benchmarks: Makefile - Initial effort to onboard Azure Linux HPC support for Superbench

### DIFF
--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -202,7 +202,7 @@ ifneq (,$(wildcard hpl-tests/Makefile))
 	tar xzf hpl-2.3.tar.gz && \
 	cp Make.Linux_zen3 hpl-2.3 && \
 	cp Make.Linux_zen4 hpl-2.3 && \
-	make all
+	make OS_SKU=$(OS_SKU) all
 	cp -v ./hpl-tests/hpl-2.3/bin/Linux_zen3/xhpl $(SB_MICRO_PATH)/bin/xhpl_z3
 	cp -v ./hpl-tests/hpl-2.3/bin/Linux_zen4/xhpl $(SB_MICRO_PATH)/bin/xhpl_z4
 	cp -v ./hpl-tests/hpl_run.sh $(SB_MICRO_PATH)/bin/
@@ -215,7 +215,7 @@ cpu_stream: sb_micro_path
 ifneq (,$(wildcard stream-tests/Makefile))
 	cd ./stream-tests && \
     wget https://www.cs.virginia.edu/stream/FTP/Code/stream.c && \
-	make all
+	make OS_SKU=$(OS_SKU) all
 	cp -v ./stream-tests/stream* $(SB_MICRO_PATH)/bin/
 endif
 

--- a/third_party/hpl-tests/Makefile
+++ b/third_party/hpl-tests/Makefile
@@ -1,26 +1,38 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+# OS_SKU is inherited from parent Makefile, but provide fallback if run independently
+OS_SKU ?= $(shell sort -r /etc/*-release | gawk 'match($$0, /^ID=(.*)$$/, a) { print toupper(a[1]); exit }')
+
 # Dynamically find AMD software paths
+ifeq ($(OS_SKU), AZURELINUX)
 BLIS_PATH := $(shell find /opt -path "*/amd-blis" 2>/dev/null | head -1)
 BLIS_LIB := $(shell find /opt -name "libblis-mt.so" 2>/dev/null | head -1)
 AOCC_PATH := $(shell find /opt -path "*/aocc-compiler*/bin/clang" 2>/dev/null | head -1)
+endif
 
 all: ZEN3 ZEN4 CONFIGURE
 
 CONFIGURE:
 	cp ./hpl-2.3/setup/Make.Linux_ATHLON_CBLAS ./hpl-2.3/Make.Linux_zen3
-	sed -i 's/.*ARCH   .*=.*/ARCH         =$$(arch)/' ./hpl-2.3/Make.Linux_zen3
-	sed -i 's/.*TOPdir .*=.*/TOPdir       = ..\/..\/../' ./hpl-2.3/Make.Linux_zen3
+	sed -i 's/.*ARCH   .*=.*/ARCH        =$$(arch)/' ./hpl-2.3/Make.Linux_zen3
+	sed -i 's/.*TOPdir .*=.*/TOPdir      = ..\/..\/../' ./hpl-2.3/Make.Linux_zen3
 	sed -i 's/.*MPdir .*=.*/MPdir        = $$(omp)/' ./hpl-2.3/Make.Linux_zen3
 	sed -i 's/.*MPinc .*=.*/MPinc        = -I$$(MPdir)\/include/' ./hpl-2.3/Make.Linux_zen3
 	sed -i 's/.*MPlib .*=.*/MPlib        = $$(MPdir)\/lib\/libmpi.so/' ./hpl-2.3/Make.Linux_zen3
+ifeq ($(OS_SKU), AZURELINUX)
 	sed -i 's|.*LAdir .*=.*|LAdir        = $(BLIS_PATH)|' ./hpl-2.3/Make.Linux_zen3
-	sed -i 's/LAinc  .*=/LAinc        = -I$$(LAdir)\/lib\/include/' ./hpl-2.3/Make.Linux_zen3
 	sed -i 's|.*LAlib .*=.*|LAlib        = $(BLIS_LIB)|' ./hpl-2.3/Make.Linux_zen3
-	sed -i 's|.*CC .*=.*|CC           = $(AOCC_PATH)|' ./hpl-2.3/Make.Linux_zen3	
+	sed -i 's|.*CC .*=.*|CC              = $(AOCC_PATH)|' ./hpl-2.3/Make.Linux_zen3	
+	sed -i 's|.*LINKER .*=.*|LINKER      = $(AOCC_PATH)|' ./hpl-2.3/Make.Linux_zen3
+else
+	sed -i 's/.*LAdir .*=.*/LAdir        = \/opt\/AMD\/amd-blis/' ./hpl-2.3/Make.Linux_zen3
+	sed -i 's/.*LAlib .*=.*/LAlib        = $$(LAdir)\/lib\/LP64\/libblis-mt.so/' ./hpl-2.3/Make.Linux_zen3
+	sed -i 's/.*CC .*=.*/CC              = \/opt\/AMD\/aocc-compiler-4.0.0\/bin\/clang/' ./hpl-2.3/Make.Linux_zen3	
+	sed -i 's/.*LINKER .*=.*/LINKER      = \/opt\/AMD\/aocc-compiler-4.0.0\/bin\/clang/' ./hpl-2.3/Make.Linux_zen3
+endif
+	sed -i 's/LAinc .*=/LAinc              = -I$$(LAdir)\/lib\/include/' ./hpl-2.3/Make.Linux_zen3
 	sed -i 's/.*CCFLAGS .*=.*/CCFLAGS      = $$(HPL_DEFS) -march=znver3 -fomit-frame-pointer -O3 -funroll-loops/' ./hpl-2.3/Make.Linux_zen3
-	sed -i 's|.*LINKER .*=.*|LINKER       = $(AOCC_PATH)|' ./hpl-2.3/Make.Linux_zen3
 	cp ./hpl-2.3/Make.Linux_zen3 ./hpl-2.3/Make.Linux_zen4
 	sed -i 's/.*CCFLAGS .*=.*/CCFLAGS      = $$(HPL_DEFS) -march=znver4 -fomit-frame-pointer -O3 -funroll-loops/' ./hpl-2.3/Make.Linux_zen4
 ZEN3: CONFIGURE

--- a/third_party/stream-tests/Makefile
+++ b/third_party/stream-tests/Makefile
@@ -1,6 +1,9 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+# OS_SKU is inherited from parent Makefile, but provide fallback if run independently
+OS_SKU ?= $(shell sort -r /etc/*-release | gawk 'match($$0, /^ID=(.*)$$/, a) { print toupper(a[1]); exit }')
+
 GENFLAGS := -DSTREAM_ARRAY_SIZE=120000000
 ZEN3FLAGS := -DSTREAM_ARRAY_SIZE=400000000 -march=znver3
 ZEN4FLAGS := -DSTREAM_ARRAY_SIZE=800000000 -march=znver4
@@ -23,8 +26,14 @@ ifeq ($(ARCH), aarch64)
 endif
 
 # AMD AOCC clang present? add ZEN3 and ZEN4
-# Dynamically find AOCC compiler installation
+# Find AOCC compiler installation
+ifeq ($(OS_SKU), AZURELINUX)
 AOCC_CLANG := $(shell find /opt -path "*/aocc-compiler*/bin/clang" 2>/dev/null | head -1)
+else
+AOCC_CLANG := $(wildcard /opt/AMD/aocc-compiler-4.0.0/bin/clang)
+endif
+
+# Configure compiler if AOCC is found
 ifneq ($(AOCC_CLANG),)
   CC      := $(AOCC_CLANG)
   CFLAGS  := -Ofast -mcmodel=large -mavx2 -ffp-contract=fast -lomp -fopenmp \


### PR DESCRIPTION
**Description**
This is an initial effort to compile and run Superbench on NVIDIA GPUs using the Azure Linux 3.0 HPC images. 

The change mainly focuses on introducing dynamic path for amd-blis and aocc compiler that are required by hpl-test and cpu-stream tests as the path name will be different from that on other types of images.

Also introduces OS_SKU check in third_party Makefile as ROCBLAS_BRANCH and HIPBLASLT_BRANCH are currently defined using dpkg which won't work for Azure Linux. Thus, also addressing to pave the way for onboarding Azure Linux support for Superbench rocm scenarios.