### PR TITLE
CI/CD - Fix Azure pipeline

### DIFF
--- a/.azure-pipelines/cpu-unit-test.yml
+++ b/.azure-pipelines/cpu-unit-test.yml
@@ -29,7 +29,7 @@ steps:
       if python3 -c "import sys; exit(0 if sys.version_info < (3, 11) else 1)"; then
         python3 -m pip install --upgrade setuptools==65.7
       fi
-      python3 -m pip install .[test,cpuworker]
+      python3 -m pip install --no-cache-dir .[test,cpuworker]
       make postinstall
     displayName: Install dependencies
   - script: |


### PR DESCRIPTION
**Description**
Azure pipeline cpu-unit-test failed for "2025-12-10T03:47:59.0628597Z ERROR: Could not install packages due to an OSError: [Errno 28] No space left on device"

**Root Cause**
This happens because the matrix jobs (Python 3.7, 3.10, 3.12) run in parallel and share the same VM's disk. Python 3.12 downloads newer/larger packages (especially PyTorch and NVIDIA CUDA libraries which are ~3GB+), and when multiple jobs run simultaneously, they exhaust the disk space.

**Fix**
Disable the cache usage when installing SB
