### PR TITLE
Benchmark: Micro benchmark - Fix precision loss in kernel launch overhead benchmark

### DIFF
--- a/superbench/benchmarks/micro_benchmarks/kernel_launch_overhead/kernel_launch.cu
+++ b/superbench/benchmarks/micro_benchmarks/kernel_launch_overhead/kernel_launch.cu
@@ -60,8 +60,7 @@ double test_cuda_kernel_launch_wall_time(int num_warmups, int num_steps) {
         EmptyKernel<<<1, 1>>>();
         cudaDeviceSynchronize();
         gettimeofday(&end_tv, NULL);
-        total_time += (end_tv.tv_sec - begin_tv.tv_sec) * 1000.0 +
-                      (end_tv.tv_usec - begin_tv.tv_usec) / 1000.0;
+        total_time += (end_tv.tv_sec - begin_tv.tv_sec) * 1000.0 + (end_tv.tv_usec - begin_tv.tv_usec) / 1000.0;
     }
 
     return total_time;

--- a/superbench/benchmarks/micro_benchmarks/kernel_launch_overhead/kernel_launch.cu
+++ b/superbench/benchmarks/micro_benchmarks/kernel_launch_overhead/kernel_launch.cu
@@ -60,8 +60,8 @@ double test_cuda_kernel_launch_wall_time(int num_warmups, int num_steps) {
         EmptyKernel<<<1, 1>>>();
         cudaDeviceSynchronize();
         gettimeofday(&end_tv, NULL);
-        total_time += (((end_tv.tv_sec) * 1000 + (end_tv.tv_usec) / 1000) -
-                       ((begin_tv.tv_sec) * 1000 + (begin_tv.tv_usec) / 1000));
+        total_time += (end_tv.tv_sec - begin_tv.tv_sec) * 1000.0 +
+                      (end_tv.tv_usec - begin_tv.tv_usec) / 1000.0;
     }
 
     return total_time;


### PR DESCRIPTION
**Description**

The original code uses integer division in the time calculation: (end_tv.tv_usec) / 1000. Since an empty kernel launch overhead is typically very small (often less than 1ms), this integer division truncates the microsecond component to 0, leading to significant precision loss and incorrect results.

<img width="396" height="164" alt="image" src="https://github.com/user-attachments/assets/5e9e6881-11d5-46d9-af4b-3243db540488" />

**Major Revision**
- Changed the divisor from 1000 to 1000. (floating-point literal). This forces floating-point arithmetic, preserving the microsecond precision required for accurate overhead measurement.
