### PR TITLE
Enhancement- Add SM80/90 architecture to CUTLASS builds for CUDA 12.8+ for A100

### DIFF
--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -42,11 +42,11 @@ sb_micro_path:
 # for cuda 12.9 and later Build from commit v3.9 (3.9 release commit) for blackwell support
 cuda_cutlass:
 ifeq ($(shell echo $(CUDA_VER)">=12.9" | bc -l), 1)
-	$(eval ARCHS := "100;103")
+	$(eval ARCHS := "80;90;100;103")
 	if [ -d cutlass ]; then rm -rf cutlass; fi
 	git clone --branch v4.1.0 --depth 1 https://github.com/NVIDIA/cutlass.git && cd cutlass
 else ifeq ($(shell echo $(CUDA_VER)">=12.8" | bc -l), 1)
-	$(eval ARCHS := "90;100")
+	$(eval ARCHS := "80;90;100")
 	if [ -d cutlass ]; then rm -rf cutlass; fi
 	git clone --branch v3.9.2 --depth 1 https://github.com/NVIDIA/cutlass.git && cd cutlass
 else ifeq ($(shell echo $(CUDA_VER)">=11.8" | bc -l), 1)

--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -270,7 +270,7 @@ apex_rocm:
 # Build MSCCL for CUDA
 cuda_msccl: sb_micro_path
 ifeq ($(shell echo $(CUDA_VER)">=12.9" | bc -l), 1)
-	$(eval ARCHS := 100 103)
+	$(eval ARCHS := 80 90 100 103)
 	if [ -d msccl ]; then rm -rf msccl; fi; \
 	git clone --single-branch --branch main https://github.com/Azure/msccl.git \
 	&& git -C msccl checkout 87048bd && git -C msccl submodule update --recursive --init

--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -39,7 +39,7 @@ sb_micro_path:
 	mkdir -p $(SB_MICRO_PATH)/lib
 
 # Build cutlass.
-# for cuda 12.9 and later Build from commit v3.9 (3.9 release commit) for blackwell support
+# For CUDA 12.9 and later, build from CUTLASS v4.1.0 (required for Blackwell support).
 cuda_cutlass:
 ifeq ($(shell echo $(CUDA_VER)">=12.9" | bc -l), 1)
 	$(eval ARCHS := "80;90;100;103")


### PR DESCRIPTION
Add sm_80 to the CUTLASS architecture lists to ensure Ampere GPU support is included in builds targeting CUDA 12.8+ for A100
