### PR TITLE
Runner: make MPI bind-to configurable

### DIFF
--- a/docs/superbench-config.mdx
+++ b/docs/superbench-config.mdx
@@ -370,6 +370,7 @@ proc_num: int
 node_num: int
 env: dict
 mca: dict
+bind_to: string
 prefix: str
 parallel: bool
 ```
@@ -403,6 +404,7 @@ Some attributes may only be suitable for specific mode.
 | `prefix`   |    ✓    |          ✘          |   ✘   |
 | `env`      |    ✓    |          ✓          |   ✓   |
 | `mca`      |    ✘    |          ✘          |   ✓   |
+| `bind_to`  |    ✘    |          ✘          |   ✓   |
 | `parallel` |    ✓    |          ✘          |   ✘   |
 | `pattern`  |    ✘    |          ✘          |   ✓   |
 
@@ -451,6 +453,16 @@ Formatted string is also supported in value, available variables include:
 MCA (Modular Component Architecture) frameworks, components, or modules to use in MPI,
 in a flatten key-value dictionary.
 Only available for `mpi` mode.
+
+### `bind_to`
+
+Process binding policy passed to `mpirun -bind-to`.
+Only available for `mpi` mode.
+
+Use this option when a benchmark needs to override the runner's default MPI binding behavior,
+for example when the benchmark implements its own topology-aware CPU/NUMA affinity logic.
+
+* default value: `numa`
 
 ### `parallel`
 

--- a/superbench/runner/runner.py
+++ b/superbench/runner/runner.py
@@ -60,6 +60,14 @@ class SuperBenchRunner():
         """
         SuperBenchLogger.add_handler(logger.logger, filename=str(self._output_path / filename))
 
+    def __validate_mpi_bind_to(self, bind_to):
+        """Validate mpi bind_to option."""
+        valid_mpi_bind_to = {'slot', 'hwthread', 'core', 'l1cache', 'l2cache', 'l3cache', 'package', 'numa', 'none'}
+        if bind_to not in valid_mpi_bind_to:
+            raise ValueError(
+                'Invalid bind_to value {}. Must be one of: {}'.format(bind_to, sorted(valid_mpi_bind_to))
+            )
+
     def __validate_sb_config(self):    # noqa: C901
         """Validate SuperBench config object.
 
@@ -93,6 +101,8 @@ class SuperBenchRunner():
                         }
                     if 'bind_to' not in mode:
                         self._sb_benchmarks[name].modes[idx].bind_to = 'numa'
+                    else:
+                        self.__validate_mpi_bind_to(mode.bind_to)
                     for key in ['PATH', 'LD_LIBRARY_PATH', 'SB_MICRO_PATH', 'SB_WORKSPACE']:
                         self._sb_benchmarks[name].modes[idx].env.setdefault(key, None)
                     if 'pattern' in mode:

--- a/superbench/runner/runner.py
+++ b/superbench/runner/runner.py
@@ -91,6 +91,8 @@ class SuperBenchRunner():
                             'btl_tcp_if_exclude': 'lo,docker0',
                             'coll_hcoll_enable': 0,
                         }
+                    if 'bind_to' not in mode:
+                        self._sb_benchmarks[name].modes[idx].bind_to = 'numa'
                     for key in ['PATH', 'LD_LIBRARY_PATH', 'SB_MICRO_PATH', 'SB_WORKSPACE']:
                         self._sb_benchmarks[name].modes[idx].env.setdefault(key, None)
                     if 'pattern' in mode:
@@ -182,13 +184,14 @@ class SuperBenchRunner():
                 '-tag-output '    # tag mpi output with [jobid,rank]<stdout/stderr> prefix
                 '-allow-run-as-root '    # allow mpirun to run when executed by root user
                 '{host_list} '    # use prepared hostfile or specify nodes and launch {proc_num} processes on each node
-                '-bind-to numa '    # bind processes to numa
+                '-bind-to {bind_to} '    # bind processes according to mode config
                 '{mca_list} {env_list} {command}'
             ).format(
                 trace=trace_command,
                 host_list=f'-host localhost:{mode.proc_num}' if 'node_num' in mode and mode.node_num == 1 else
                 f'-hostfile hostfile -map-by ppr:{mode.proc_num}:node' if 'host_list' not in mode else '-host ' +
                 ','.join(f'{host}:{mode.proc_num}' for host in mode.host_list),
+                bind_to=mode.bind_to,
                 mca_list=' '.join(f'-mca {k} {v}' for k, v in mode.mca.items()),
                 env_list=' '.join(
                     f'-x {k}={str(v).format(proc_rank=mode.proc_rank, proc_num=mode.proc_num)}'

--- a/superbench/runner/runner.py
+++ b/superbench/runner/runner.py
@@ -64,9 +64,7 @@ class SuperBenchRunner():
         """Validate mpi bind_to option."""
         valid_mpi_bind_to = {'slot', 'hwthread', 'core', 'l1cache', 'l2cache', 'l3cache', 'package', 'numa', 'none'}
         if bind_to not in valid_mpi_bind_to:
-            raise ValueError(
-                'Invalid bind_to value {}. Must be one of: {}'.format(bind_to, sorted(valid_mpi_bind_to))
-            )
+            raise ValueError('Invalid bind_to value {}. Must be one of: {}'.format(bind_to, sorted(valid_mpi_bind_to)))
 
     def __validate_sb_config(self):    # noqa: C901
         """Validate SuperBench config object.

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -56,6 +56,8 @@ class RunnerTestCase(unittest.TestCase):
                     self.assertIn('proc_num', mode)
                 if mode.name == 'mpi':
                     self.assertIn('mca', mode)
+                    self.assertIn('bind_to', mode)
+                    self.assertEqual('numa', mode.bind_to)
 
     def test_get_failure_count(self):
         """Test get_failure_count."""
@@ -153,6 +155,7 @@ class RunnerTestCase(unittest.TestCase):
                     'name': 'mpi',
                     'proc_num': 8,
                     'proc_rank': 1,
+                    'bind_to': 'numa',
                     'mca': {},
                     'env': {
                         'PATH': None,
@@ -172,6 +175,7 @@ class RunnerTestCase(unittest.TestCase):
                     'name': 'mpi',
                     'proc_num': 8,
                     'proc_rank': 2,
+                    'bind_to': 'numa',
                     'mca': {
                         'coll_hcoll_enable': 0,
                     },
@@ -196,6 +200,7 @@ class RunnerTestCase(unittest.TestCase):
                     'node_num': 1,
                     'proc_num': 8,
                     'proc_rank': 2,
+                    'bind_to': 'numa',
                     'mca': {
                         'coll_hcoll_enable': 0,
                     },
@@ -219,6 +224,7 @@ class RunnerTestCase(unittest.TestCase):
                     'name': 'mpi',
                     'proc_num': 8,
                     'proc_rank': 1,
+                    'bind_to': 'numa',
                     'mca': {},
                     'pattern': {
                         'type': 'all-nodes',
@@ -231,6 +237,44 @@ class RunnerTestCase(unittest.TestCase):
                 'expected_command': (
                     'mpirun -tag-output -allow-run-as-root -host node0:8,node1:8 -bind-to numa '
                     ' -x PATH -x LD_LIBRARY_PATH '
+                    f'sb exec --output-dir {self.sb_output_dir} -c sb.config.yaml -C superbench.enable=foo'
+                ),
+            },
+            {
+                'benchmark_name':
+                'foo',
+                'mode': {
+                    'name': 'mpi',
+                    'proc_num': 8,
+                    'proc_rank': 0,
+                    'bind_to': 'core',
+                    'mca': {},
+                    'env': {
+                        'PATH': None,
+                    },
+                },
+                'expected_command': (
+                    'mpirun -tag-output -allow-run-as-root -hostfile hostfile -map-by ppr:8:node -bind-to core '
+                    ' -x PATH '
+                    f'sb exec --output-dir {self.sb_output_dir} -c sb.config.yaml -C superbench.enable=foo'
+                ),
+            },
+            {
+                'benchmark_name':
+                'foo',
+                'mode': {
+                    'name': 'mpi',
+                    'proc_num': 8,
+                    'proc_rank': 0,
+                    'bind_to': 'none',
+                    'mca': {},
+                    'env': {
+                        'PATH': None,
+                    },
+                },
+                'expected_command': (
+                    'mpirun -tag-output -allow-run-as-root -hostfile hostfile -map-by ppr:8:node -bind-to none '
+                    ' -x PATH '
                     f'sb exec --output-dir {self.sb_output_dir} -c sb.config.yaml -C superbench.enable=foo'
                 ),
             },
@@ -263,6 +307,21 @@ class RunnerTestCase(unittest.TestCase):
                         test_case['timeout'],
                     ), expected_command
                 )
+
+    def test_validate_sb_config_invalid_mpi_bind_to(self):
+        """Test validate_sb_config rejects unsupported mpi bind_to values."""
+        test_config_file = Path(__file__).parent / '../../tests/data/test.yaml'
+        with test_config_file.open() as fp:
+            invalid_config = OmegaConf.create(yaml.load(fp, Loader=yaml.SafeLoader))
+        invalid_config.superbench.benchmarks['nccl-bw:all-nodes'].modes[0].bind_to = 'socket'
+
+        with self.assertRaisesRegex(ValueError, 'Invalid bind_to value'):
+            SuperBenchRunner(
+                invalid_config,
+                OmegaConf.create({}),
+                OmegaConf.create({}),
+                self.sb_output_dir,
+            )
 
     def test_run_empty_benchmarks(self):
         """Test run empty benchmarks, nothing should happen."""


### PR DESCRIPTION
**Description**

Make MPI process binding configurable in SuperBench runner modes so benchmarks with their own topology-aware affinity logic can disable the default `-bind-to numa` behavior when needed.

**Major Revision**

- Add a new optional `bind_to` field for `mpi` modes in the runner
- Keep backward compatibility by defaulting `bind_to` to `numa`
- Update MPI command generation to use the configured `bind_to` value instead of a hard-coded `numa`
