### PR TITLE
SysInfo - Fix NIC info collection in sys_info output

### DIFF
--- a/docs/user-tutorial/system-config.md
+++ b/docs/user-tutorial/system-config.md
@@ -22,7 +22,7 @@ This tool is to collect the system information automatically on the tested GPU n
 
 2. Start to collect the sys info using `sb node info --output-dir ${output-dir}` command using root privilege.
 
-3. After the command finished, you can find the output system info json file `sys-info.json` of local node under \${output_dir}.
+3. After the command finished, you can find the output system info json file `sys_info.json` of local node under \${output_dir}.
 
 ### Usage on multiple remote machines
 
@@ -38,7 +38,7 @@ This tool is to collect the system information automatically on the tested GPU n
   sb run --get-info -f host.ini --output-dir ${output-dir} -C superbench.enable=none
   ```
 
-4. After the command finished, you can find the output system info json file `sys-info.json` of each node under \${output_dir}/nodes/${node_name}.
+4. After the command finished, you can find the output system info json file `sys_info.json` of each node under \${output_dir}/nodes/${node_name}.
 
 ## Parameter and Details
 

--- a/superbench/tools/system_info.py
+++ b/superbench/tools/system_info.py
@@ -421,6 +421,7 @@ class SystemInfo():    # pragma: no cover
                 nic_list.append(nic_info)
         except Exception:
             logger.exception('Error: get nic info failed')
+        return nic_list
 
     def get_network(self):
         """Get network info, including nic info, ib info and ofed version.


### PR DESCRIPTION
**Description**
Fix two issues in system info collection: NIC information was collected but not returned, and the documentation referenced the wrong output filename.

**Major Revision**
- Return the collected NIC list from `SystemInfo.get_nic()`, so `Network.nic` is populated in `sys_info.json`.

**Minor Revision**
- Update system config documentation to use the actual output filename `sys_info.json` instead of `sys-info.json`.