### PR TITLE
CI/CD - Clean up image builds, remove cuda 12.8/12.4/12.2 and add cuda13.0 merge

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -175,8 +175,6 @@ jobs:
       contents: read
       packages: write
     strategy:
-      # Keep merging independent CUDA manifests even if one merge leg fails, so a
-      # single failed build does not block publishing other successfully built images.
       fail-fast: false
       matrix:
         include:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -41,18 +41,6 @@ jobs:
           platforms: linux/amd64
           runner: [self-hosted, linux/amd64]
           build_args: "NUM_MAKE_JOBS=16"
-        - name: cuda12.8-arm64
-          dockerfile: cuda12.8
-          tags: superbench/main:cuda12.8-arm64
-          platforms: linux/arm64
-          runner: [self-hosted, linux/arm64]
-          build_args: "NUM_MAKE_JOBS=16"
-        - name: cuda12.8-amd64
-          dockerfile: cuda12.8
-          tags: superbench/main:cuda12.8-amd64
-          platforms: linux/amd64
-          runner: [self-hosted, linux/amd64]
-          build_args: "NUM_MAKE_JOBS=16"
         - name: cuda12.9-arm64
           dockerfile: cuda12.9
           tags: superbench/main:cuda12.9-arm64
@@ -62,18 +50,6 @@ jobs:
         - name: cuda12.9-amd64
           dockerfile: cuda12.9
           tags: superbench/main:cuda12.9-amd64
-          platforms: linux/amd64
-          runner: [self-hosted, linux/amd64]
-          build_args: "NUM_MAKE_JOBS=16"
-        - name: cuda12.4
-          dockerfile: cuda12.4
-          tags: superbench/main:cuda12.4
-          platforms: linux/amd64
-          runner: [self-hosted, linux/amd64]
-          build_args: "NUM_MAKE_JOBS=16"
-        - name: cuda12.2
-          dockerfile: cuda12.2
-          tags: superbench/main:cuda12.2
           platforms: linux/amd64
           runner: [self-hosted, linux/amd64]
           build_args: "NUM_MAKE_JOBS=16"
@@ -191,7 +167,7 @@ jobs:
         run: echo ${{ steps.docker_build.outputs.digest }}
   docker-merge:
     needs: docker-build
-    if: ${{ !cancelled() }}
+    if: ${{ success() }}
     name: Docker merge ${{ matrix.name }}
     runs-on: self-hosted
     timeout-minutes: 300
@@ -201,16 +177,16 @@ jobs:
     strategy:
       matrix:
         include:
-        - name: cuda12.8
-          tags: superbench/main:cuda12.8
-          sources: >-
-            superbench/main:cuda12.8-amd64
-            superbench/main:cuda12.8-arm64
         - name: cuda12.9
           tags: superbench/main:cuda12.9
           sources: >-
             superbench/main:cuda12.9-amd64
             superbench/main:cuda12.9-arm64
+        - name: cuda13.0
+          tags: superbench/main:cuda13.0
+          sources: >-
+            superbench/main:cuda13.0-amd64
+            superbench/main:cuda13.0-arm64
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -167,7 +167,7 @@ jobs:
         run: echo ${{ steps.docker_build.outputs.digest }}
   docker-merge:
     needs: docker-build
-    if: ${{ success() }}
+    if: ${{ !cancelled() }}
     name: Docker merge ${{ matrix.name }}
     runs-on: self-hosted
     timeout-minutes: 300
@@ -175,6 +175,9 @@ jobs:
       contents: read
       packages: write
     strategy:
+      # Keep merging independent CUDA manifests even if one merge leg fails, so a
+      # single failed build does not block publishing other successfully built images.
+      fail-fast: false
       matrix:
         include:
         - name: cuda12.9


### PR DESCRIPTION
## Description
Clean up the Docker image build matrix in `build-image.yml`.

### Changes
- Remove the `docker-build` entries for cuda 12.8, 12.4, and 12.2.
- Remove the corresponding cuda12.8 `docker-merge` entry and add a cuda13.0 merge entry (merging `amd64` + `arm64`), alongside the existing cuda12.9 merge.
- Add `fail-fast: false` to the `docker-merge` matrix so a failed merge for one CUDA version does not cancel the other merge legs. The job keeps `if: ${{ !cancelled() }}` so merges still run as long as the workflow was not cancelled.

### Notes
- The `docker-merge` condition is intentionally `!cancelled()` (not `success()`): the `docker-build` matrix uses `fail-fast: false` because the self-hosted ROCm build can fail transiently, and we don't want a flaky ROCm build to block merging the CUDA images.
