### PR TITLE
Bugfix - Use torchrun --standalone for single-node torch.distributed runs

### DIFF
--- a/superbench/runner/runner.py
+++ b/superbench/runner/runner.py
@@ -152,7 +152,6 @@ class SuperBenchRunner():
             mode_command = ' '.join(command_parts)
             mode_command = f'PROC_RANK={mode.proc_rank} {mode_command}'
         elif mode.name == 'torch.distributed':
-            # TODO: replace with torch.distributed.run in v1.9
             # TODO: only supports node_num=1 and node_num=all currently
             # For single-node runs use torchrun's standalone rendezvous, which binds a random free
             # port instead of the fixed default (29500). This avoids transient EADDRINUSE failures

--- a/superbench/runner/runner.py
+++ b/superbench/runner/runner.py
@@ -154,8 +154,11 @@ class SuperBenchRunner():
         elif mode.name == 'torch.distributed':
             # TODO: replace with torch.distributed.run in v1.9
             # TODO: only supports node_num=1 and node_num=all currently
+            # For single-node runs use torchrun's standalone rendezvous, which binds a random free
+            # port instead of the fixed default (29500). This avoids transient EADDRINUSE failures
+            # when consecutive distributed benchmarks reuse the same rendezvous port.
             torch_dist_params = (
-                '' if 'node_num' in mode and mode.node_num == 1 else
+                '--standalone ' if 'node_num' in mode and mode.node_num == 1 else
                 '--nnodes=$NNODES --node_rank=$NODE_RANK --master_addr=$MASTER_ADDR --master_port=$MASTER_PORT '
             )
 

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -141,6 +141,7 @@ class RunnerTestCase(unittest.TestCase):
                 'expected_command': (
                     'torchrun '
                     '--no_python --nproc_per_node=8 '
+                    '--standalone '
                     f'sb exec --output-dir {self.sb_output_dir} -c sb.config.yaml -C superbench.enable=foo '
                     'superbench.benchmarks.foo.parameters.distributed_impl=ddp '
                     'superbench.benchmarks.foo.parameters.distributed_backend=nccl'


### PR DESCRIPTION
**Description**

When the runner builds a `torchrun` command for a `torch.distributed`-mode benchmark with `node_num == 1`, it passes **no rendezvous arguments at all**. In that case `torchrun` falls back to its own default rendezvous, which binds a **fixed** port (`MASTER_PORT=29500`). If a previous distributed job's socket on that same port hasn't fully cleared the kernel's `TIME_WAIT` state yet, the next single-node job's `torchrun` fails to bind with:

```
DistNetworkError: ... port: 29500 ... EADDRINUSE
```

This was observed for `model-benchmarks:resnet` during a full `sb run` on an MI300X host (Ansible-level failure, before the benchmark executor even started, so no result appears in the results summary at all). This PR switches the single-node case to `torchrun --standalone`, which spins up its own local rendezvous on a **randomly chosen free port** instead of a fixed one, eliminating the port-reuse race entirely.

**Why this wasn't caught earlier**

This is not a new bug: the `node_num == 1` → empty rendezvous-args code path has existed since the `torch.distributed` mode was first added to the runner in 2021 (#81). It never surfaced as a visible failure before because it's a timing-dependent race, not a deterministic defect in any specific benchmark:

- `superbench/config/amd_mi300.yaml` shows `gpt`, `bert`, `lstm`, `resnet`, `densenet`, and `vgg` under `model-benchmarks` all share the *identical* `default_pytorch_mode` anchor (`torch.distributed`, `proc_num: 8`, `node_num: 1`), so every one of them goes through the exact same fixed-port code path — yet only `resnet` hit `EADDRINUSE` in the observed run, while `gpt`/`bert`/`lstm` passed. That rules out anything resnet-specific.
- The failure depends on whether the *previous* job to use port 29500 released its socket (cleared `TIME_WAIT`) before the *next* single-node job attempts to bind. That gap is a function of exact benchmark scheduling/ordering and per-run timing, so it only manifests when two single-node jobs happen to land close enough together — which is why this only showed up on this particular full end-to-end 462-benchmark run and not in smaller/prior runs.

**Major Revision**
- `superbench/runner/runner.py` (`__get_mode_command`): for `torch.distributed` mode with `node_num == 1`, pass `--standalone` instead of no rendezvous args. Multi-node path (`--nnodes=$NNODES --node_rank=$NODE_RANK --master_addr=$MASTER_ADDR --master_port=$MASTER_PORT`) is unchanged.

**Minor Revision**
- `tests/runner/test_runner.py`: updated `test_get_mode_command`'s expected single-node command string to include `--standalone`.

**Testing**
- `test_get_mode_command` passes with the updated expectation.
- Verified in-container on an 8x MI300X host: `torchrun --nproc_per_node=2` (old default) always binds `MASTER_PORT=29500`; with `--standalone`, back-to-back single-node runs picked distinct random ports (45635, then 36937) with no `EADDRINUSE`.