### PR TITLE
Dockerfile - Upgrade bundled Docker to 29.7.2 in cuda13.0

### DIFF
--- a/dockerfile/cuda13.0.dockerfile
+++ b/dockerfile/cuda13.0.dockerfile
@@ -3,7 +3,7 @@ FROM nvcr.io/nvidia/pytorch:25.08-py3
 # OS:
 #   - Ubuntu: 24.04
 #   - OpenMPI: 4.1.9a1
-#   - Docker Client: 20.10.8 (installed in this dockerfile)
+#   - Docker Client: 29.7.2 (installed in this dockerfile)
 # NVIDIA:
 #   - CUDA: 13.0.0.044
 #   - cuDNN: 9.12.0.46
@@ -67,7 +67,7 @@ ARG TARGETPLATFORM
 ARG TARGETARCH
 
 # Install Docker
-ENV DOCKER_VERSION=20.10.8
+ENV DOCKER_VERSION=29.7.2
 RUN TARGETARCH_HW=$(uname -m) && \
     wget -q https://download.docker.com/linux/static/stable/${TARGETARCH_HW}/docker-${DOCKER_VERSION}.tgz -O docker.tgz && \
     tar --extract --file docker.tgz --strip-components 1 --directory /usr/local/bin/ && \

--- a/dockerfile/cuda13.0.dockerfile
+++ b/dockerfile/cuda13.0.dockerfile
@@ -3,7 +3,7 @@ FROM nvcr.io/nvidia/pytorch:25.08-py3
 # OS:
 #   - Ubuntu: 24.04
 #   - OpenMPI: 4.1.9a1
-#   - Docker Client: 29.7.2 (installed in this dockerfile)
+#   - Docker: 29.7.2 (full static bundle installed in this dockerfile)
 # NVIDIA:
 #   - CUDA: 13.0.0.044
 #   - cuDNN: 9.12.0.46


### PR DESCRIPTION
**Description**

The bundled Docker static distribution is pinned at `20.10.8`, which was built with Go 1.16.6. A Trivy 0.72.0 scan of `superbench.azurecr.io/internal/hpc:main-cuda13.0` (2026-07-15) reports **40 Critical occurrences** against the eight binaries this Dockerfile unpacks into `/usr/local/bin/`. That is **69% of the 58 Critical findings in the image**, and the largest single source of Critical findings we own.

These are compiled-in Go dependencies, not installed packages, so they cannot be fixed with `apt` or `pip`. The bundle itself has to be replaced.

Docker `29.7.2` (released 2026-08-05) is built with Go 1.26.5 and carries gRPC `v1.82.1`, which clears every CVE reported against this bundle:

| CVE | Component | Occurrences | Required fix | 29.7.2 ships |
| --- | --- | ---: | --- | --- |
| CVE-2025-68121 | Go `stdlib` | 8 | `1.24.13, 1.25.7, 1.26.0-rc.3` | `go1.26.5` |
| CVE-2022-23806 | Go `stdlib` | 8 | `1.16.14, 1.17.7` | `go1.26.5` |
| CVE-2023-24538 | Go `stdlib` | 8 | `1.19.8, 1.20.3` | `go1.26.5` |
| CVE-2023-24540 | Go `stdlib` | 8 | `1.19.9, 1.20.4` | `go1.26.5` |
| CVE-2024-24790 | Go `stdlib` | 8 | `1.21.11, 1.22.4` | `go1.26.5` |

**Major Revision**
- Bump `DOCKER_VERSION` from `20.10.8` to `29.7.2` in `dockerfile/cuda13.0.dockerfile`.

**Minor Revision**
- Update the Docker line in the version comment header to the new version, and correct it to say the full static bundle is installed rather than only the client.

---

### Verification done before opening

Both architecture tarballs were downloaded from `download.docker.com/linux/static/stable/` and inspected:

- `x86_64/docker-29.7.2.tgz` and `aarch64/docker-29.7.2.tgz` both return 200. `${TARGETARCH_HW}` already resolves correctly for both.
- Every binary in the bundle reports `go1.26.5`, on both architectures.
- `dockerd` embeds `google.golang.org/grpc v1.82.1`.
- The extracted client is statically linked and reports `Docker version 29.7.2, build a7dcaa6`.

### Host compatibility

SuperBench only uses the Docker **client** against the host daemon socket (`monitor.py`, `docker_base.py`, `runner.py`, `system_info.py`, and `deploy.yaml`, which mounts `/var/run/docker.sock`). There is no reference to `dockerd`, `containerd`, `runc`, `ctr`, or `docker-proxy` anywhere in the tree.

Docker `29.3.0` **lowered** the minimum daemon API version from v1.44 back to **v1.40 (Docker 19.03)**, so the newer client still talks to older host daemons. `docker login --username/--password` and every subcommand we invoke are still present in 29.7.2.

One behavioural note for reviewers: the v1 `containerd-shim` binary no longer ships in the 29.x bundle. Nothing in this repository references it.

### Draft, pending

- [ ] `cuda13.0` image builds on arm64 and amd64
- [ ] `docker --version` inside the built image reports 29.7.2
- [ ] Rescan the pushed digest per architecture and confirm the 40 occurrences are gone, and that 29.7.2 introduces no new findings from its other Go modules

### Not in this PR

- The same bump for `rocm6.3.x.dockerfile` (Docker `27.5.1`, 8 Critical), which is a separate PR because it is a different vendor image, different runner, and different reviewers.
- `cuda12.9` and `cuda11.1.1` are also built by CI and still carry `20.10.8`. They were not scanned, but they install the same bundle. Happy to extend this PR to them if reviewers prefer.
- Installing only the `docker` client instead of the full bundle. That would drop 7 unused binaries and ~181 MB, but it changes image contents rather than a version string, so it is left as a follow-up.
- Checksum verification of the downloaded tarball. Worth doing, but it is the same gap in every `dockerfile/*.dockerfile` here, so it belongs in one change across all of them rather than only this one.
- The base-image-inherited findings (`linux-libc-dev`, `jupyter_server`, Nsight), which are handled by a CUDA 13.3 base upgrade.