### PR TITLE
Dockerfile - Add cuda13.3.dockerfile on pytorch:26.07-py3

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -29,15 +29,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - name: cuda13.0-arm64
-          dockerfile: cuda13.0
-          tags: superbench/main:cuda13.0-arm64
+        - name: cuda13.3-arm64
+          dockerfile: cuda13.3
+          tags: superbench/main:cuda13.3-arm64
           platforms: linux/arm64
           runner: [self-hosted, linux/arm64]
           build_args: "NUM_MAKE_JOBS=16"
-        - name: cuda13.0-amd64
-          dockerfile: cuda13.0
-          tags: superbench/main:cuda13.0-amd64
+        - name: cuda13.3-amd64
+          dockerfile: cuda13.3
+          tags: superbench/main:cuda13.3-amd64
           platforms: linux/amd64
           runner: [self-hosted, linux/amd64]
           build_args: "NUM_MAKE_JOBS=16"
@@ -183,11 +183,11 @@ jobs:
           sources: >-
             superbench/main:cuda12.9-amd64
             superbench/main:cuda12.9-arm64
-        - name: cuda13.0
-          tags: superbench/main:cuda13.0
+        - name: cuda13.3
+          tags: superbench/main:cuda13.3
           sources: >-
-            superbench/main:cuda13.0-amd64
-            superbench/main:cuda13.0-arm64
+            superbench/main:cuda13.3-amd64
+            superbench/main:cuda13.3-arm64
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/dockerfile/cuda13.3.dockerfile
+++ b/dockerfile/cuda13.3.dockerfile
@@ -12,7 +12,7 @@ FROM nvcr.io/nvidia/pytorch:26.07-py3
 #   - TransformerEngine: v2.17
 #   - torch: 2.13.0a0+9186a08
 # Mellanox:
-#   - MOFED_VERSION: (installed in this dockerfile)
+#   - MOFED: 24.10-1.1.4.0 (installed in this dockerfile)
 #   - HPC-X: 2.50
 # Intel:
 #   - mlc: 3.12 (amd64 only)
@@ -93,8 +93,7 @@ RUN TARGETARCH_HW=$(uname -m) && \
     rm -rf /tmp/MLNX_OFED_LINUX-${OFED_VERSION}*
 
 # Install HPC-X
-# Keep in sync with the base image, which ships HPC-X 2.50. A lower version here
-# would replace /opt/hpcx with an older stack than PyTorch was built against.
+# Must match the base image, because this replaces /opt/hpcx wholesale.
 ENV HPCX_VERSION=v2.50
 RUN TARGETARCH_HW=$(uname -m) && \
     cd /opt && \
@@ -126,8 +125,7 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
     fi
 
 # Install UCX with multi-threading support
-# /usr/local/lib precedes the base image libraries in LD_LIBRARY_PATH, so this
-# version has to match the base image's UCX 1.21.0 to stay ABI compatible.
+# Must match the base image: /usr/local/lib precedes it in LD_LIBRARY_PATH.
 ENV UCX_VERSION=1.21.0
 RUN cd /tmp && \
     wget https://github.com/openucx/ucx/releases/download/v${UCX_VERSION}/ucx-${UCX_VERSION}.tar.gz && \
@@ -158,9 +156,7 @@ ADD third_party third_party
 RUN make -C third_party cuda
 
 ADD . .
-# 81.0.0 is what the base image already ships; pinned so the build stays reproducible.
-RUN python3 -m pip install --upgrade setuptools==81.0.0 && \
-    python3 -m pip install --no-cache-dir .[nvworker] && \
+RUN python3 -m pip install --no-cache-dir .[nvworker] && \
     make cppbuild && \
     make postinstall && \
     rm -rf .git

--- a/dockerfile/cuda13.3.dockerfile
+++ b/dockerfile/cuda13.3.dockerfile
@@ -158,7 +158,8 @@ ADD third_party third_party
 RUN make -C third_party cuda
 
 ADD . .
-RUN python3 -m pip install --upgrade "setuptools>=78.1.1" && \
+# 81.0.0 is what the base image already ships; pinned so the build stays reproducible.
+RUN python3 -m pip install --upgrade setuptools==81.0.0 && \
     python3 -m pip install --no-cache-dir .[nvworker] && \
     make cppbuild && \
     make postinstall && \

--- a/dockerfile/cuda13.3.dockerfile
+++ b/dockerfile/cuda13.3.dockerfile
@@ -3,7 +3,7 @@ FROM nvcr.io/nvidia/pytorch:26.07-py3
 # OS:
 #   - Ubuntu: 24.04
 #   - OpenMPI: 5.0.10
-#   - Docker Client: 29.7.2 (installed in this dockerfile)
+#   - Docker: 29.7.2 (full static bundle installed in this dockerfile)
 # NVIDIA:
 #   - CUDA: 13.3.1.008
 #   - cuDNN: 9.24.0.43

--- a/dockerfile/cuda13.3.dockerfile
+++ b/dockerfile/cuda13.3.dockerfile
@@ -122,7 +122,7 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
     mv amd-blis /opt/AMD && \
     rm -rf aocl-blis-linux-aocc-4.0.tar.gz; \
     else \
-    echo "Skipping Intel MLC, AOCC and AMD Bliss installations for non-amd64 architecture: $TARGETARCH"; \
+    echo "Skipping Intel MLC, AOCC and AMD BLIS installations for non-amd64 architecture: $TARGETARCH"; \
     fi
 
 # Install UCX with multi-threading support

--- a/dockerfile/cuda13.3.dockerfile
+++ b/dockerfile/cuda13.3.dockerfile
@@ -1,0 +1,165 @@
+FROM nvcr.io/nvidia/pytorch:26.07-py3
+
+# OS:
+#   - Ubuntu: 24.04
+#   - OpenMPI: 5.0.10
+#   - Docker Client: 29.7.2 (installed in this dockerfile)
+# NVIDIA:
+#   - CUDA: 13.3.1.008
+#   - cuDNN: 9.24.0.43
+#   - cuBLAS: 13.6.0.2
+#   - NCCL: 2.30.7
+#   - TransformerEngine: v2.17
+#   - torch: 2.13.0a0+9186a08
+# Mellanox:
+#   - MOFED_VERSION: (installed in this dockerfile)
+#   - HPC-X: 2.50
+# Intel:
+#   - mlc: 3.12 (amd64 only)
+
+LABEL maintainer="SuperBench"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    autoconf \
+    automake \
+    bc \
+    build-essential \
+    curl \
+    dmidecode \
+    ffmpeg \
+    git \
+    iproute2 \
+    jq \
+    libaio-dev \
+    libavcodec-dev \
+    libavformat-dev \
+    libavutil-dev \
+    libboost-program-options-dev \
+    libcap2 \
+    libcurl4-openssl-dev \
+    libnuma-dev \
+    libpci-dev \
+    libswresample-dev \
+    libncurses-dev \
+    libtool \
+    lshw \
+    python3-mpi4py \
+    net-tools \
+    nlohmann-json3-dev \
+    openssh-client \
+    openssh-server \
+    pciutils \
+    sudo \
+    util-linux \
+    vim \
+    wget \
+    rsync \
+    && \
+    apt-get autoremove && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/*
+
+ARG NUM_MAKE_JOBS=
+ARG TARGETPLATFORM
+ARG TARGETARCH
+
+# Install Docker
+ENV DOCKER_VERSION=29.7.2
+RUN TARGETARCH_HW=$(uname -m) && \
+    wget -q https://download.docker.com/linux/static/stable/${TARGETARCH_HW}/docker-${DOCKER_VERSION}.tgz -O docker.tgz && \
+    tar --extract --file docker.tgz --strip-components 1 --directory /usr/local/bin/ && \
+    rm docker.tgz
+
+# Update system config
+RUN mkdir -p /root/.ssh && \
+    touch /root/.ssh/authorized_keys && \
+    mkdir -p /var/run/sshd && \
+    sed -i "s/[# ]*PermitRootLogin prohibit-password/PermitRootLogin yes/" /etc/ssh/sshd_config && \
+    sed -i "s/[# ]*PermitUserEnvironment no/PermitUserEnvironment yes/" /etc/ssh/sshd_config && \
+    sed -i "s/[# ]*Port.*/Port 22/" /etc/ssh/sshd_config && \
+    echo "* soft nofile 1048576\n* hard nofile 1048576" >> /etc/security/limits.conf && \
+    echo "root soft nofile 1048576\nroot hard nofile 1048576" >> /etc/security/limits.conf
+
+# Install OFED
+ENV OFED_VERSION=24.10-1.1.4.0
+RUN TARGETARCH_HW=$(uname -m) && \
+    cd /tmp && \
+    wget -q https://content.mellanox.com/ofed/MLNX_OFED-${OFED_VERSION}/MLNX_OFED_LINUX-${OFED_VERSION}-ubuntu24.04-${TARGETARCH_HW}.tgz && \
+    tar xzf MLNX_OFED_LINUX-${OFED_VERSION}-ubuntu24.04-${TARGETARCH_HW}.tgz && \
+    MLNX_OFED_LINUX-${OFED_VERSION}-ubuntu24.04-${TARGETARCH_HW}/mlnxofedinstall --user-space-only --without-fw-update --without-ucx-cuda --force --all && \
+    rm -rf /tmp/MLNX_OFED_LINUX-${OFED_VERSION}*
+
+# Install HPC-X
+# Keep in sync with the base image, which ships HPC-X 2.50. A lower version here
+# would replace /opt/hpcx with an older stack than PyTorch was built against.
+ENV HPCX_VERSION=v2.50
+RUN TARGETARCH_HW=$(uname -m) && \
+    cd /opt && \
+    rm -rf hpcx && \
+    wget https://content.mellanox.com/hpc/hpc-x/${HPCX_VERSION}_cuda13/hpcx-${HPCX_VERSION}-gcc-doca_ofed-ubuntu24.04-cuda13-${TARGETARCH_HW}.tbz -O hpcx.tbz && \
+    tar xf hpcx.tbz && \
+    mv hpcx-${HPCX_VERSION}-gcc-doca_ofed-ubuntu24.04-cuda13-${TARGETARCH_HW} hpcx && \
+    rm hpcx.tbz
+
+# Installs specific to amd64 platform
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+    # Install Intel MLC
+    cd /tmp && \
+    wget -q https://downloadmirror.intel.com/866182/mlc_v3.12.tgz -O mlc.tgz && \
+    tar xzf mlc.tgz Linux/mlc && \
+    cp ./Linux/mlc /usr/local/bin/ && \
+    rm -rf ./Linux mlc.tgz && \
+    # Install AOCC compiler
+    wget https://download.amd.com/developer/eula/aocc-compiler/aocc-compiler-4.0.0_1_amd64.deb && \
+    apt install -y ./aocc-compiler-4.0.0_1_amd64.deb && \
+    rm -rf aocc-compiler-4.0.0_1_amd64.deb && \
+    # Install AMD BLIS
+    wget https://download.amd.com/developer/eula/blis/blis-4-0/aocl-blis-linux-aocc-4.0.tar.gz && \
+    tar xzf aocl-blis-linux-aocc-4.0.tar.gz && \
+    mv amd-blis /opt/AMD && \
+    rm -rf aocl-blis-linux-aocc-4.0.tar.gz; \
+    else \
+    echo "Skipping Intel MLC, AOCC and AMD Bliss installations for non-amd64 architecture: $TARGETARCH"; \
+    fi
+
+# Install UCX with multi-threading support
+# /usr/local/lib precedes the base image libraries in LD_LIBRARY_PATH, so this
+# version has to match the base image's UCX 1.21.0 to stay ABI compatible.
+ENV UCX_VERSION=1.21.0
+RUN cd /tmp && \
+    wget https://github.com/openucx/ucx/releases/download/v${UCX_VERSION}/ucx-${UCX_VERSION}.tar.gz && \
+    tar xzf ucx-${UCX_VERSION}.tar.gz && \
+    cd ucx-${UCX_VERSION} && \
+    ./contrib/configure-release-mt --prefix=/usr/local && \
+    make -j ${NUM_MAKE_JOBS} && \
+    make install
+
+ENV PATH="${PATH}" \
+    LD_LIBRARY_PATH="/usr/local/lib:/usr/local/mpi/lib:${LD_LIBRARY_PATH}" \
+    SB_HOME=/opt/superbench \
+    SB_MICRO_PATH=/opt/superbench \
+    ANSIBLE_DEPRECATION_WARNINGS=FALSE \
+    ANSIBLE_COLLECTIONS_PATH=/usr/share/ansible/collections
+
+RUN echo PATH="$PATH" > /etc/environment && \
+    echo LD_LIBRARY_PATH="$LD_LIBRARY_PATH" >> /etc/environment && \
+    echo SB_MICRO_PATH="$SB_MICRO_PATH" >> /etc/environment && \
+    echo "source /opt/hpcx/hpcx-init.sh && hpcx_load" | tee -a /etc/bash.bashrc >> /etc/profile.d/10-hpcx.sh
+
+# Add config files
+ADD dockerfile/etc /opt/microsoft/
+
+WORKDIR ${SB_HOME}
+
+ADD third_party third_party
+RUN make -C third_party cuda
+
+ADD . .
+RUN python3 -m pip install --upgrade "setuptools>=78.1.1" && \
+    python3 -m pip install --no-cache-dir .[nvworker] && \
+    make cppbuild && \
+    make postinstall && \
+    rm -rf .git

--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -39,7 +39,7 @@ sb_micro_path:
 	mkdir -p $(SB_MICRO_PATH)/lib
 
 # Build cutlass.
-# for cuda 12.9 and later Build from commit v3.9 (3.9 release commit) for blackwell support
+# The CUTLASS tag is picked per CUDA_VER because each release only supports the SM archs of its own CUDA generation.
 cuda_cutlass:
 ifeq ($(shell echo $(CUDA_VER)">=13.3" | bc -l), 1)
 	$(eval ARCHS := "100;103")

--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -41,7 +41,11 @@ sb_micro_path:
 # Build cutlass.
 # for cuda 12.9 and later Build from commit v3.9 (3.9 release commit) for blackwell support
 cuda_cutlass:
-ifeq ($(shell echo $(CUDA_VER)">=12.9" | bc -l), 1)
+ifeq ($(shell echo $(CUDA_VER)">=13.3" | bc -l), 1)
+	$(eval ARCHS := "100;103")
+	if [ -d cutlass ]; then rm -rf cutlass; fi
+	git clone --branch v4.7.0 --depth 1 https://github.com/NVIDIA/cutlass.git && cd cutlass
+else ifeq ($(shell echo $(CUDA_VER)">=12.9" | bc -l), 1)
 	$(eval ARCHS := "100;103")
 	if [ -d cutlass ]; then rm -rf cutlass; fi
 	git clone --branch v4.1.0 --depth 1 https://github.com/NVIDIA/cutlass.git && cd cutlass

--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -39,7 +39,7 @@ sb_micro_path:
 	mkdir -p $(SB_MICRO_PATH)/lib
 
 # Build cutlass.
-# The CUTLASS tag is picked per CUDA_VER because each release only supports the SM archs of its own CUDA generation.
+# Tag tracks the CUDA toolkit: v4.7.0 documents optimal codegen for 13.3, v4.1.0 for 12.9.
 cuda_cutlass:
 ifeq ($(shell echo $(CUDA_VER)">=13.3" | bc -l), 1)
 	$(eval ARCHS := "100;103")


### PR DESCRIPTION
**Description**
Adds `dockerfile/cuda13.3.dockerfile` on `nvcr.io/nvidia/pytorch:26.07-py3` and rotates the CI matrix from `cuda13.0` (`25.08-py3`) to it. This is the usual one-Dockerfile-per-CUDA-version rotation, same shape as #716 and #819.

The security side is worth calling out, because it decides what else had to change here. Trivy 0.72.0 on `main-cuda13.0` reports 58 Critical occurrences from exactly two places: 18 inherited from the NVIDIA base image, 40 from the Docker `20.10.8` static bundle we install. The base bump closes the first group; the second is why `DOCKER_VERSION` moves in the same PR rather than being left for later. Supersedes #845, now closed.

**Major Revision**
- Add `dockerfile/cuda13.3.dockerfile` on `26.07-py3`: CUDA 13.3.1, PyTorch 2.13.0a0, cuDNN 9.24, NCCL 2.30.7, OpenMPI 5.0.10. Clears the 18 inherited findings (`linux-libc-dev`, `jupyter_server`, the Nsight Go plugin).
- `DOCKER_VERSION` `20.10.8` -> `29.7.2`. The other 40 are Go stdlib CVEs compiled into the binaries the `RUN` unpacks, so apt and pip can't reach them and the bundle has to be replaced. We only use the Docker client against the host socket, and 29.3.0 lowered the daemon API floor back to v1.40 (Docker 19.03), so older hosts keep working.
- Point the `docker-build` and `docker-merge` matrices at `cuda13.3`.
- `third_party/Makefile`: add a `CUDA_VER >= 13.3` branch selecting CUTLASS `v4.7.0`. The `>= 12.9` branch would otherwise pick `v4.1.0`, which predates CUDA 13.3.

**Minor Revision**
- `HPCX_VERSION` -> `v2.50` and `UCX_VERSION` -> `1.21.0`, both matching the base. Not cosmetic: the HPC-X block does `rm -rf /opt/hpcx` and `/usr/local/lib` comes first in `LD_LIBRARY_PATH`, so an older pin would shadow part of the stack PyTorch was built against.
- Drop the `setuptools` pin instead of carrying it over. `cuda13.0` pins `78.1.0`, which against this base is both a downgrade and CVE-2025-47273.
- Refresh the version comment header for `26.07-py3` and fill in the MOFED version, which was blank.
- Replace the stale comment above `cuda_cutlass`; it claimed 12.9+ builds `v3.9` while the recipe already cloned `v4.1.0`.

**Verification**
Both legs build: arm64 36 min, amd64 35 min on `9c8274f9` — the only change since is the removed `setuptools` pin, which arm64 has already rebuilt with. Scanning the result has to wait for merge, since `docker-build` sets `push: false` on pull requests.

**Open questions**
- Copilot flags the unverified Docker tarball download and the `PermitRootLogin`/`PermitUserEnvironment` lines. Both are real but inherited: no Dockerfile here verifies a download, and both `sed` lines come from #43 (2021) across all 14 sshd-bearing images. Worth noting Docker publishes no checksums for the static bundles, so any check would be a self-computed pin rather than upstream verification. I'd rather sweep `dockerfile/*.dockerfile` once than have `cuda13.3` diverge; happy to fold it in here instead.
- `cuda13.0.dockerfile` stays in place, following #819. `cuda12.9`, `cuda11.1.1` and `rocm6.3.x` still carry Docker `20.10.8`/`27.5.1`, roughly 40 and 8 Critical — separate PR, or fold in here?